### PR TITLE
Implement complete database relationship structure for semantic CMS

### DIFF
--- a/drizzle/0001_update_relationships.sql
+++ b/drizzle/0001_update_relationships.sql
@@ -1,0 +1,187 @@
+-- Drop old tables that don't match the new structure
+DROP TABLE IF EXISTS "element_templates" CASCADE;
+DROP TABLE IF EXISTS "feeds" CASCADE;
+DROP TABLE IF EXISTS "presentations" CASCADE;
+
+-- Update posts table structure (remove feed reference, add publication and preset references)
+ALTER TABLE "posts" DROP CONSTRAINT IF EXISTS "posts_feed_id_feeds_id_fk";
+ALTER TABLE "posts" DROP COLUMN IF EXISTS "feed_id";
+ALTER TABLE "posts" ADD COLUMN "publication_id" uuid NOT NULL;
+ALTER TABLE "posts" ADD COLUMN "preset_id" uuid NOT NULL;
+ALTER TABLE "posts" ALTER COLUMN "slug" DROP NOT NULL;
+ALTER TABLE "posts" ALTER COLUMN "content" DROP NOT NULL;
+
+-- Update pages table structure (remove user reference, add product reference)
+ALTER TABLE "pages" DROP CONSTRAINT IF EXISTS "pages_user_id_users_id_fk";
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "user_id";
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "title";
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "content";
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "is_published";
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "published_at";
+ALTER TABLE "pages" DROP CONSTRAINT IF EXISTS "pages_slug_unique";
+ALTER TABLE "pages" ADD COLUMN "name" varchar(255) NOT NULL;
+ALTER TABLE "pages" ADD COLUMN "product_id" uuid NOT NULL;
+
+-- Update partials table structure (remove user reference and slug)
+ALTER TABLE "partials" DROP CONSTRAINT IF EXISTS "partials_user_id_users_id_fk";
+ALTER TABLE "partials" DROP COLUMN IF EXISTS "user_id";
+ALTER TABLE "partials" DROP COLUMN IF EXISTS "slug";
+ALTER TABLE "partials" DROP COLUMN IF EXISTS "description";
+ALTER TABLE "partials" DROP COLUMN IF EXISTS "elements";
+
+-- Create products table
+CREATE TABLE "products" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"user_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create parts table
+CREATE TABLE "parts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"page_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create primitives table (renamed from element_templates)
+CREATE TABLE "primitives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"tag_name" varchar(50) NOT NULL,
+	"attributes" json,
+	"default_content" text,
+	"css_styles" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create publications table
+CREATE TABLE "publications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"product_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create presets table
+CREATE TABLE "presets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"publication_id" uuid,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create projects table
+CREATE TABLE "projects" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"product_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create pieces table
+CREATE TABLE "pieces" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"slug" varchar(255) NOT NULL,
+	"project_id" uuid NOT NULL,
+	"preset_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Create junction tables for many-to-many relationships
+CREATE TABLE "part_partials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"part_id" uuid NOT NULL,
+	"partial_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "part_primitives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"part_id" uuid NOT NULL,
+	"primitive_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "partial_primitives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"partial_id" uuid NOT NULL,
+	"primitive_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "post_partials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"partial_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "post_primitives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"primitive_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "preset_parts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"preset_id" uuid NOT NULL,
+	"part_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "piece_partials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"piece_id" uuid NOT NULL,
+	"partial_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "piece_primitives" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"piece_id" uuid NOT NULL,
+	"primitive_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+-- Add foreign key constraints
+ALTER TABLE "products" ADD CONSTRAINT "products_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "pages" ADD CONSTRAINT "pages_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "parts" ADD CONSTRAINT "parts_page_id_pages_id_fk" FOREIGN KEY ("page_id") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "publications" ADD CONSTRAINT "publications_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "presets" ADD CONSTRAINT "presets_publication_id_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."publications"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "posts" ADD CONSTRAINT "posts_publication_id_publications_id_fk" FOREIGN KEY ("publication_id") REFERENCES "public"."publications"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "posts" ADD CONSTRAINT "posts_preset_id_presets_id_fk" FOREIGN KEY ("preset_id") REFERENCES "public"."presets"("id") ON DELETE restrict ON UPDATE no action;
+ALTER TABLE "projects" ADD CONSTRAINT "projects_product_id_products_id_fk" FOREIGN KEY ("product_id") REFERENCES "public"."products"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "pieces" ADD CONSTRAINT "pieces_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "pieces" ADD CONSTRAINT "pieces_preset_id_presets_id_fk" FOREIGN KEY ("preset_id") REFERENCES "public"."presets"("id") ON DELETE restrict ON UPDATE no action;
+
+-- Add foreign keys for junction tables
+ALTER TABLE "part_partials" ADD CONSTRAINT "part_partials_part_id_parts_id_fk" FOREIGN KEY ("part_id") REFERENCES "public"."parts"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "part_partials" ADD CONSTRAINT "part_partials_partial_id_partials_id_fk" FOREIGN KEY ("partial_id") REFERENCES "public"."partials"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "part_primitives" ADD CONSTRAINT "part_primitives_part_id_parts_id_fk" FOREIGN KEY ("part_id") REFERENCES "public"."parts"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "part_primitives" ADD CONSTRAINT "part_primitives_primitive_id_primitives_id_fk" FOREIGN KEY ("primitive_id") REFERENCES "public"."primitives"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "partial_primitives" ADD CONSTRAINT "partial_primitives_partial_id_partials_id_fk" FOREIGN KEY ("partial_id") REFERENCES "public"."partials"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "partial_primitives" ADD CONSTRAINT "partial_primitives_primitive_id_primitives_id_fk" FOREIGN KEY ("primitive_id") REFERENCES "public"."primitives"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "post_partials" ADD CONSTRAINT "post_partials_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "post_partials" ADD CONSTRAINT "post_partials_partial_id_partials_id_fk" FOREIGN KEY ("partial_id") REFERENCES "public"."partials"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "post_primitives" ADD CONSTRAINT "post_primitives_post_id_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."posts"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "post_primitives" ADD CONSTRAINT "post_primitives_primitive_id_primitives_id_fk" FOREIGN KEY ("primitive_id") REFERENCES "public"."primitives"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "preset_parts" ADD CONSTRAINT "preset_parts_preset_id_presets_id_fk" FOREIGN KEY ("preset_id") REFERENCES "public"."presets"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "preset_parts" ADD CONSTRAINT "preset_parts_part_id_parts_id_fk" FOREIGN KEY ("part_id") REFERENCES "public"."parts"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "piece_partials" ADD CONSTRAINT "piece_partials_piece_id_pieces_id_fk" FOREIGN KEY ("piece_id") REFERENCES "public"."pieces"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "piece_partials" ADD CONSTRAINT "piece_partials_partial_id_partials_id_fk" FOREIGN KEY ("partial_id") REFERENCES "public"."partials"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "piece_primitives" ADD CONSTRAINT "piece_primitives_piece_id_pieces_id_fk" FOREIGN KEY ("piece_id") REFERENCES "public"."pieces"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "piece_primitives" ADD CONSTRAINT "piece_primitives_primitive_id_primitives_id_fk" FOREIGN KEY ("primitive_id") REFERENCES "public"."primitives"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1757678720354,
       "tag": "0000_bitter_human_fly",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1757678720355,
+      "tag": "0001_update_relationships",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -11,129 +11,357 @@ export const users = pgTable('users', {
 	updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
-// Feeds - collections where posts can be added
-export const feeds = pgTable('feeds', {
+// Products - main container for user's products
+export const products = pgTable('products', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	name: varchar('name', { length: 255 }).notNull(),
-	slug: varchar('slug', { length: 255 }).notNull().unique(),
-	description: text('description'),
-	isPublic: boolean('is_public').notNull().default(true),
 	userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
 	createdAt: timestamp('created_at').notNull().defaultNow(),
 	updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
-// Posts - content items that can be added to feeds
-export const posts = pgTable('posts', {
-	id: uuid('id').primaryKey().defaultRandom(),
-	title: varchar('title', { length: 500 }).notNull(),
-	slug: varchar('slug', { length: 500 }).notNull(),
-	content: json('content').notNull(), // Array of partial instances with filled data
-	isPublished: boolean('is_published').notNull().default(false),
-	publishedAt: timestamp('published_at'),
-	userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-	feedId: uuid('feed_id').notNull().references(() => feeds.id, { onDelete: 'cascade' }),
-	createdAt: timestamp('created_at').notNull().defaultNow(),
-	updatedAt: timestamp('updated_at').notNull().defaultNow()
-});
-
-// Pages - standalone one-off pages
+// Pages - belong to products
 export const pages = pgTable('pages', {
-	id: uuid('id').primaryKey().defaultRandom(),
-	title: varchar('title', { length: 500 }).notNull(),
-	slug: varchar('slug', { length: 500 }).notNull().unique(),
-	content: json('content').notNull(), // Array of partial instances with filled data
-	isPublished: boolean('is_published').notNull().default(false),
-	publishedAt: timestamp('published_at'),
-	userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-	createdAt: timestamp('created_at').notNull().defaultNow(),
-	updatedAt: timestamp('updated_at').notNull().defaultNow()
-});
-
-// Partials - reusable components made of semantic HTML elements
-export const partials = pgTable('partials', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	name: varchar('name', { length: 255 }).notNull(),
 	slug: varchar('slug', { length: 255 }).notNull(),
-	description: text('description'),
-	elements: json('elements').notNull(), // Array of semantic HTML elements with their structure
-	userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+	productId: uuid('product_id').notNull().references(() => products.id, { onDelete: 'cascade' }),
 	createdAt: timestamp('created_at').notNull().defaultNow(),
 	updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
-// Element Templates - predefined semantic HTML elements that can be used in partials
-export const elementTemplates = pgTable('element_templates', {
+// Parts - belong to pages
+export const parts = pgTable('parts', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	name: varchar('name', { length: 255 }).notNull(),
-	tagName: varchar('tag_name', { length: 50 }).notNull(), // h1, p, section, etc.
-	attributes: json('attributes'), // Default attributes like class, id, etc.
-	isContentEditable: boolean('is_content_editable').notNull().default(true),
+	pageId: uuid('page_id').notNull().references(() => pages.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Partials - reusable components
+export const partials = pgTable('partials', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	name: varchar('name', { length: 255 }).notNull(),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Primitives - basic building blocks
+export const primitives = pgTable('primitives', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	name: varchar('name', { length: 255 }).notNull(),
+	tagName: varchar('tag_name', { length: 50 }).notNull(),
+	attributes: json('attributes'),
 	defaultContent: text('default_content'),
-	cssStyles: text('css_styles'), // CSS rules for this element
-	description: text('description'),
+	cssStyles: text('css_styles'),
 	createdAt: timestamp('created_at').notNull().defaultNow(),
 	updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
 
-// Presentations - visual style definitions that can be applied
-export const presentations = pgTable('presentations', {
+// Publications - belong to products
+export const publications = pgTable('publications', {
 	id: uuid('id').primaryKey().defaultRandom(),
 	name: varchar('name', { length: 255 }).notNull(),
-	slug: varchar('slug', { length: 255 }).notNull().unique(),
-	cssVariables: json('css_variables'), // CSS custom properties
-	globalStyles: text('global_styles'), // Global CSS rules
-	userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
-	isActive: boolean('is_active').notNull().default(false),
+	slug: varchar('slug', { length: 255 }).notNull(),
+	productId: uuid('product_id').notNull().references(() => products.id, { onDelete: 'cascade' }),
 	createdAt: timestamp('created_at').notNull().defaultNow(),
 	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Presets - templates that can be used by posts and pieces
+export const presets = pgTable('presets', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	name: varchar('name', { length: 255 }).notNull(),
+	publicationId: uuid('publication_id').references(() => publications.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Posts - belong to publications and use presets
+export const posts = pgTable('posts', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	title: varchar('title', { length: 500 }).notNull(),
+	slug: varchar('slug', { length: 500 }),
+	content: json('content'),
+	publicationId: uuid('publication_id').notNull().references(() => publications.id, { onDelete: 'cascade' }),
+	presetId: uuid('preset_id').notNull().references(() => presets.id, { onDelete: 'restrict' }),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Projects - belong to products
+export const projects = pgTable('projects', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	name: varchar('name', { length: 255 }).notNull(),
+	slug: varchar('slug', { length: 255 }).notNull(),
+	productId: uuid('product_id').notNull().references(() => products.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Pieces - belong to projects and use presets
+export const pieces = pgTable('pieces', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	name: varchar('name', { length: 255 }).notNull(),
+	slug: varchar('slug', { length: 255 }).notNull(),
+	projectId: uuid('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+	presetId: uuid('preset_id').notNull().references(() => presets.id, { onDelete: 'restrict' }),
+	createdAt: timestamp('created_at').notNull().defaultNow(),
+	updatedAt: timestamp('updated_at').notNull().defaultNow()
+});
+
+// Junction tables for many-to-many relationships
+
+// Parts to Partials relationship
+export const partPartials = pgTable('part_partials', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	partId: uuid('part_id').notNull().references(() => parts.id, { onDelete: 'cascade' }),
+	partialId: uuid('partial_id').notNull().references(() => partials.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Parts to Primitives relationship
+export const partPrimitives = pgTable('part_primitives', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	partId: uuid('part_id').notNull().references(() => parts.id, { onDelete: 'cascade' }),
+	primitiveId: uuid('primitive_id').notNull().references(() => primitives.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Partials to Primitives relationship
+export const partialPrimitives = pgTable('partial_primitives', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	partialId: uuid('partial_id').notNull().references(() => partials.id, { onDelete: 'cascade' }),
+	primitiveId: uuid('primitive_id').notNull().references(() => primitives.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Posts to Partials relationship
+export const postPartials = pgTable('post_partials', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	postId: uuid('post_id').notNull().references(() => posts.id, { onDelete: 'cascade' }),
+	partialId: uuid('partial_id').notNull().references(() => partials.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Posts to Primitives relationship
+export const postPrimitives = pgTable('post_primitives', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	postId: uuid('post_id').notNull().references(() => posts.id, { onDelete: 'cascade' }),
+	primitiveId: uuid('primitive_id').notNull().references(() => primitives.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Presets to Parts relationship
+export const presetParts = pgTable('preset_parts', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	presetId: uuid('preset_id').notNull().references(() => presets.id, { onDelete: 'cascade' }),
+	partId: uuid('part_id').notNull().references(() => parts.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Pieces to Partials relationship
+export const piecePartials = pgTable('piece_partials', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	pieceId: uuid('piece_id').notNull().references(() => pieces.id, { onDelete: 'cascade' }),
+	partialId: uuid('partial_id').notNull().references(() => partials.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
+});
+
+// Pieces to Primitives relationship
+export const piecePrimitives = pgTable('piece_primitives', {
+	id: uuid('id').primaryKey().defaultRandom(),
+	pieceId: uuid('piece_id').notNull().references(() => pieces.id, { onDelete: 'cascade' }),
+	primitiveId: uuid('primitive_id').notNull().references(() => primitives.id, { onDelete: 'cascade' }),
+	createdAt: timestamp('created_at').notNull().defaultNow()
 });
 
 // Relations
 export const usersRelations = relations(users, ({ many }) => ({
-	feeds: many(feeds),
-	posts: many(posts),
+	products: many(products)
+}));
+
+export const productsRelations = relations(products, ({ one, many }) => ({
+	user: one(users, {
+		fields: [products.userId],
+		references: [users.id]
+	}),
 	pages: many(pages),
-	partials: many(partials),
-	presentations: many(presentations)
+	publications: many(publications),
+	projects: many(projects)
 }));
 
-export const feedsRelations = relations(feeds, ({ one, many }) => ({
-	user: one(users, {
-		fields: [feeds.userId],
-		references: [users.id]
+export const pagesRelations = relations(pages, ({ one, many }) => ({
+	product: one(products, {
+		fields: [pages.productId],
+		references: [products.id]
 	}),
-	posts: many(posts)
+	parts: many(parts)
 }));
 
-export const postsRelations = relations(posts, ({ one }) => ({
-	user: one(users, {
-		fields: [posts.userId],
-		references: [users.id]
+export const partsRelations = relations(parts, ({ one, many }) => ({
+	page: one(pages, {
+		fields: [parts.pageId],
+		references: [pages.id]
 	}),
-	feed: one(feeds, {
-		fields: [posts.feedId],
-		references: [feeds.id]
+	partPartials: many(partPartials),
+	partPrimitives: many(partPrimitives),
+	presetParts: many(presetParts)
+}));
+
+export const partialsRelations = relations(partials, ({ many }) => ({
+	partPartials: many(partPartials),
+	partialPrimitives: many(partialPrimitives),
+	postPartials: many(postPartials),
+	piecePartials: many(piecePartials)
+}));
+
+export const primitivesRelations = relations(primitives, ({ many }) => ({
+	partPrimitives: many(partPrimitives),
+	partialPrimitives: many(partialPrimitives),
+	postPrimitives: many(postPrimitives),
+	piecePrimitives: many(piecePrimitives)
+}));
+
+export const publicationsRelations = relations(publications, ({ one, many }) => ({
+	product: one(products, {
+		fields: [publications.productId],
+		references: [products.id]
+	}),
+	posts: many(posts),
+	presets: many(presets)
+}));
+
+export const presetsRelations = relations(presets, ({ one, many }) => ({
+	publication: one(publications, {
+		fields: [presets.publicationId],
+		references: [publications.id]
+	}),
+	posts: many(posts),
+	pieces: many(pieces),
+	presetParts: many(presetParts)
+}));
+
+export const postsRelations = relations(posts, ({ one, many }) => ({
+	publication: one(publications, {
+		fields: [posts.publicationId],
+		references: [publications.id]
+	}),
+	preset: one(presets, {
+		fields: [posts.presetId],
+		references: [presets.id]
+	}),
+	postPartials: many(postPartials),
+	postPrimitives: many(postPrimitives)
+}));
+
+export const projectsRelations = relations(projects, ({ one, many }) => ({
+	product: one(products, {
+		fields: [projects.productId],
+		references: [products.id]
+	}),
+	pieces: many(pieces)
+}));
+
+export const piecesRelations = relations(pieces, ({ one, many }) => ({
+	project: one(projects, {
+		fields: [pieces.projectId],
+		references: [projects.id]
+	}),
+	preset: one(presets, {
+		fields: [pieces.presetId],
+		references: [presets.id]
+	}),
+	piecePartials: many(piecePartials),
+	piecePrimitives: many(piecePrimitives)
+}));
+
+// Junction table relations
+export const partPartialsRelations = relations(partPartials, ({ one }) => ({
+	part: one(parts, {
+		fields: [partPartials.partId],
+		references: [parts.id]
+	}),
+	partial: one(partials, {
+		fields: [partPartials.partialId],
+		references: [partials.id]
 	})
 }));
 
-export const pagesRelations = relations(pages, ({ one }) => ({
-	user: one(users, {
-		fields: [pages.userId],
-		references: [users.id]
+export const partPrimitivesRelations = relations(partPrimitives, ({ one }) => ({
+	part: one(parts, {
+		fields: [partPrimitives.partId],
+		references: [parts.id]
+	}),
+	primitive: one(primitives, {
+		fields: [partPrimitives.primitiveId],
+		references: [primitives.id]
 	})
 }));
 
-export const partialsRelations = relations(partials, ({ one }) => ({
-	user: one(users, {
-		fields: [partials.userId],
-		references: [users.id]
+export const partialPrimitivesRelations = relations(partialPrimitives, ({ one }) => ({
+	partial: one(partials, {
+		fields: [partialPrimitives.partialId],
+		references: [partials.id]
+	}),
+	primitive: one(primitives, {
+		fields: [partialPrimitives.primitiveId],
+		references: [primitives.id]
 	})
 }));
 
-export const presentationsRelations = relations(presentations, ({ one }) => ({
-	user: one(users, {
-		fields: [presentations.userId],
-		references: [users.id]
+export const postPartialsRelations = relations(postPartials, ({ one }) => ({
+	post: one(posts, {
+		fields: [postPartials.postId],
+		references: [posts.id]
+	}),
+	partial: one(partials, {
+		fields: [postPartials.partialId],
+		references: [partials.id]
+	})
+}));
+
+export const postPrimitivesRelations = relations(postPrimitives, ({ one }) => ({
+	post: one(posts, {
+		fields: [postPrimitives.postId],
+		references: [posts.id]
+	}),
+	primitive: one(primitives, {
+		fields: [postPrimitives.primitiveId],
+		references: [primitives.id]
+	})
+}));
+
+export const presetPartsRelations = relations(presetParts, ({ one }) => ({
+	preset: one(presets, {
+		fields: [presetParts.presetId],
+		references: [presets.id]
+	}),
+	part: one(parts, {
+		fields: [presetParts.partId],
+		references: [parts.id]
+	})
+}));
+
+export const piecePartialsRelations = relations(piecePartials, ({ one }) => ({
+	piece: one(pieces, {
+		fields: [piecePartials.pieceId],
+		references: [pieces.id]
+	}),
+	partial: one(partials, {
+		fields: [piecePartials.partialId],
+		references: [partials.id]
+	})
+}));
+
+export const piecePrimitivesRelations = relations(piecePrimitives, ({ one }) => ({
+	piece: one(pieces, {
+		fields: [piecePrimitives.pieceId],
+		references: [pieces.id]
+	}),
+	primitive: one(primitives, {
+		fields: [piecePrimitives.primitiveId],
+		references: [primitives.id]
 	})
 }));


### PR DESCRIPTION
## Summary
- Implemented complete database relationship structure for the semantic CMS
- Added Products as main containers with hierarchical Pages → Parts structure  
- Created Publications with Posts and Presets for content management
- Added Projects with Pieces for project-based content
- Implemented Partials and Primitives as reusable building blocks
- Set up proper many-to-many relationships through junction tables

## Changes Made
- **New core entities**: Products, Parts, Publications, Presets, Projects, Pieces, Primitives
- **Removed legacy tables**: feeds, presentations, element_templates
- **Updated existing tables**: posts, pages, partials with new relationships
- **Added junction tables** for all many-to-many relationships
- **Database migration** created and applied successfully

## Relationships Implemented
- User → many Products
- Product → many Pages, Publications, Projects  
- Page → many Parts
- Part → many Partials, many Primitives
- Publication → many Posts, many Presets
- Post → one Preset, many Partials, many Primitives
- Project → many Pieces
- Piece → one Preset, many Partials, many Primitives
- Preset → many Parts
- Partial → many Primitives

🤖 Generated with [Claude Code](https://claude.ai/code)