### PR TITLE
Fix Svelte 5 TypeScript compilation error in profile page

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -45,7 +45,7 @@
 	let setupLoading = $state(false)
 	let setupMessage = $state('')
 
-	async function saveProfile(event: Event) {
+	async function saveProfile(event) {
 		event.preventDefault()
 		isSaving = true
 		saveMessage = ''
@@ -85,7 +85,7 @@
 		saveMessage = ''
 	}
 
-	async function changeUserPassword(event: Event) {
+	async function changeUserPassword(event) {
 		event.preventDefault()
 		isChangingPassword = true
 		passwordMessage = ''


### PR DESCRIPTION
## Summary
- Remove TypeScript type annotations from event parameters in profile page functions
- Fixes compilation error: "Unexpected token" at Event type annotation
- Functions now work correctly with Svelte 5 runes mode

## Test plan
- [x] Profile page loads without compilation errors
- [x] Form submission functions work correctly
- [x] No regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)