### PR TITLE
Fix project selector overlay not opening

### DIFF
--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -119,6 +119,7 @@
 		</section>
 	</nav>
 </header>
+{/if}
 
 <Overlay isOpen={showProjectOverlay} onClose={closeProjectOverlay} title="Select Project">
 	{#snippet children()}
@@ -128,7 +129,6 @@
 		/>
 	{/snippet}
 </Overlay>
-{/if}
 
 <style>
 	header {


### PR DESCRIPTION
## Summary
• Fixed project selector overlay not appearing when the header button is clicked
• Moved Overlay component outside authentication conditional blocks

## Test plan
- [ ] Click the project selector button in the header when logged in
- [ ] Verify the overlay opens with the project selector component
- [ ] Verify the overlay can be closed by clicking the backdrop or close button

🤖 Generated with [Claude Code](https://claude.ai/code)