### PR TITLE
Fix authentication pattern in route server files

### DIFF
--- a/src/routes/packets/pieces/[id]/edit/+page.server.ts
+++ b/src/routes/packets/pieces/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { piece, packet, project, preset, publication } from '$lib/server/db/sche
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.userId) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -25,7 +25,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(piece.id, params.id),
-			eq(project.userId, locals.session.userId)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -42,7 +42,7 @@ export const load = async ({ params, locals }) => {
 	})
 	.from(packet)
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.userId))
+	.where(eq(project.userId, user.id))
 	
 	// Get user's presets (from packets)
 	const userPresets = await db.select({
@@ -53,7 +53,7 @@ export const load = async ({ params, locals }) => {
 	.from(preset)
 	.innerJoin(packet, eq(preset.packetId, packet.id))
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.userId))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		piece: pieceQuery[0],

--- a/src/routes/packets/pieces/new/+page.server.ts
+++ b/src/routes/packets/pieces/new/+page.server.ts
@@ -3,10 +3,10 @@ import { project, project, preset, publication } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
+export async function load({ parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -18,7 +18,7 @@ export const load = async ({ locals }) => {
 	})
 	.from(project)
 	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	// Get user's presets (from their publications)
 	const userPresets = await db.select({
@@ -29,7 +29,7 @@ export const load = async ({ locals }) => {
 	.from(preset)
 	.innerJoin(publication, eq(preset.publicationId, publication.id))
 	.innerJoin(project, eq(publication.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		projects: userProjects,

--- a/src/routes/packets/presets/[id]/edit/+page.server.ts
+++ b/src/routes/packets/presets/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { preset, project, project } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -24,7 +24,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(preset.id, params.id),
-			eq(project.userId, locals.session.user.id)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -41,7 +41,7 @@ export const load = async ({ params, locals }) => {
 	})
 	.from(project)
 	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		preset: preset[0],

--- a/src/routes/packets/presets/new/+page.server.ts
+++ b/src/routes/packets/presets/new/+page.server.ts
@@ -3,10 +3,10 @@ import { project, project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
+export async function load({ parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -18,7 +18,7 @@ export const load = async ({ locals }) => {
 	})
 	.from(project)
 	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		projects: userProjects

--- a/src/routes/pieces/[id]/edit/+page.server.ts
+++ b/src/routes/pieces/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { piece, packet, project, preset } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -25,7 +25,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(piece.id, params.id),
-			eq(project.userId, locals.session.user.id)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -42,7 +42,7 @@ export const load = async ({ params, locals }) => {
 	})
 	.from(packet)
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	// Get user's presets (from packets)
 	const userPresets = await db.select({
@@ -53,7 +53,7 @@ export const load = async ({ params, locals }) => {
 	.from(preset)
 	.innerJoin(packet, eq(preset.packetId, packet.id))
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		piece: pieceQuery[0],

--- a/src/routes/pieces/new/+page.server.ts
+++ b/src/routes/pieces/new/+page.server.ts
@@ -3,8 +3,10 @@ import { project, packet, preset } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
-	if (!locals.session?.user?.id) {
+export async function load({ parent }) {
+	const { user } = await parent()
+
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -16,7 +18,7 @@ export const load = async ({ locals }) => {
 	})
 	.from(packet)
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	// Get user's presets (from their packets)
 	const userPresets = await db.select({
@@ -27,7 +29,7 @@ export const load = async ({ locals }) => {
 	.from(preset)
 	.innerJoin(packet, eq(preset.packetId, packet.id))
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		packets: userPackets,

--- a/src/routes/pieces/packets/[id]/edit/+page.server.ts
+++ b/src/routes/pieces/packets/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { packet, project } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.userId) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -23,7 +23,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(packet.id, params.id),
-			eq(project.userId, locals.session.userId)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -33,7 +33,7 @@ export const load = async ({ params, locals }) => {
 	}
 	
 	// Get user's projects for the form
-	const userProjects = await db.select().from(project).where(eq(project.userId, locals.session.userId))
+	const userProjects = await db.select().from(project).where(eq(project.userId, user.id))
 	
 	return {
 		packet: packetQuery[0],

--- a/src/routes/pieces/presets/[id]/edit/+page.server.ts
+++ b/src/routes/pieces/presets/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { preset, project, project } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -24,7 +24,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(preset.id, params.id),
-			eq(project.userId, locals.session.user.id)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -41,7 +41,7 @@ export const load = async ({ params, locals }) => {
 	})
 	.from(project)
 	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		preset: preset[0],

--- a/src/routes/pieces/presets/new/+page.server.ts
+++ b/src/routes/pieces/presets/new/+page.server.ts
@@ -3,10 +3,10 @@ import { project, project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
+export async function load({ parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -18,7 +18,7 @@ export const load = async ({ locals }) => {
 	})
 	.from(project)
 	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		projects: userProjects

--- a/src/routes/posts/presets/[id]/edit/+page.server.ts
+++ b/src/routes/posts/presets/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { preset, publication, project } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -24,7 +24,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(preset.id, params.id),
-			eq(project.userId, locals.session.user.id)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -41,7 +41,7 @@ export const load = async ({ params, locals }) => {
 	})
 	.from(publication)
 	.innerJoin(project, eq(publication.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		preset: preset[0],

--- a/src/routes/posts/presets/new/+page.server.ts
+++ b/src/routes/posts/presets/new/+page.server.ts
@@ -3,10 +3,10 @@ import { publication, project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
-	
-	
-	if (!locals.session?.user?.id) {
+export async function load({ parent }) {
+	const { user } = await parent()
+
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -18,7 +18,7 @@ export const load = async ({ locals }) => {
 	})
 	.from(publication)
 	.innerJoin(project, eq(publication.projectId, project.id))
-	.where(eq(project.userId, locals.session.user.id))
+	.where(eq(project.userId, user.id))
 	
 	return {
 		publications: userPublications

--- a/src/routes/posts/publications/[id]/edit/+page.server.ts
+++ b/src/routes/posts/publications/[id]/edit/+page.server.ts
@@ -3,10 +3,10 @@ import { publication, project } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export const load = async ({ params, locals }) => {
+export async function load({ params, parent }) {
+	const { user } = await parent()
 	
-	
-	if (!locals.session?.user?.id) {
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -24,7 +24,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(publication.id, params.id),
-			eq(project.userId, locals.session.user.id)
+			eq(project.userId, user.id)
 		)
 	)
 	.limit(1)
@@ -34,7 +34,7 @@ export const load = async ({ params, locals }) => {
 	}
 	
 	// Get all user's projects for the select field
-	const userProjects = await db.select().from(project).where(eq(project.userId, locals.session.user.id))
+	const userProjects = await db.select().from(project).where(eq(project.userId, user.id))
 	
 	return {
 		publication: publication[0],

--- a/src/routes/posts/publications/new/+page.server.ts
+++ b/src/routes/posts/publications/new/+page.server.ts
@@ -3,15 +3,15 @@ import { project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export const load = async ({ locals }) => {
-	
-	
-	if (!locals.session?.user?.id) {
+export async function load({ parent }) {
+	const { user } = await parent()
+
+	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
 	// Get all user's projects for the select field
-	const userProjects = await db.select().from(project).where(eq(project.userId, locals.session.user.id))
+	const userProjects = await db.select().from(project).where(eq(project.userId, user.id))
 	
 	return {
 		projects: userProjects


### PR DESCRIPTION
## Summary
Fixed login redirect issue where pieces, presets, and publications routes were incorrectly redirecting to login screen even when authenticated.

• Fixed inconsistent authentication patterns across 13 route server files
• Changed from `locals.session?.user` to `const { user } = await parent()` 
• Updated function declarations from arrow to named functions
• Ensured all routes use parent context data for authentication

## Test plan
- [ ] Test creating new pieces - should no longer redirect to login
- [ ] Test creating project presets - should no longer redirect to login  
- [ ] Test creating publications - should no longer redirect to login
- [ ] Test creating publication presets - should no longer redirect to login
- [ ] Verify existing functionality still works for pages, posts, and packets

🤖 Generated with [Claude Code](https://claude.ai/code)