### PR TITLE
Fix 405 Method Not Allowed error in project selector

### DIFF
--- a/src/routes/api/projects/+server.ts
+++ b/src/routes/api/projects/+server.ts
@@ -1,7 +1,23 @@
 import { json } from '@sveltejs/kit'
 import { db } from '$lib/server/db'
 import { project, publication, packet } from '$lib/server/db/schema'
+import { eq } from 'drizzle-orm'
 import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user?.id) {
+		return json({ error: 'Unauthorized' }, { status: 401 })
+	}
+	
+	try {
+		const projects = await db.select().from(project).where(eq(project.userId, locals.user.id))
+		
+		return json({ projects })
+	} catch (error) {
+		console.error('Error fetching projects:', error)
+		return json({ error: 'Failed to fetch projects' }, { status: 500 })
+	}
+}
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!locals.user?.id) {


### PR DESCRIPTION
## Summary
- Add GET handler to `/api/projects` endpoint to allow fetching user's projects
- Fix 405 Method Not Allowed error that was preventing the project selector from loading
- The ProjectSelector component was making GET requests to an endpoint that only supported POST

## Test plan
- [ ] Verify project selector loads without errors
- [ ] Confirm user's projects are displayed in the selector
- [ ] Test that creating new projects still works (POST handler unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)