### PR TITLE
Fix PostgreSQL syntax error in pieces presets route

### DIFF
--- a/src/routes/pieces/presets/new/+page.server.ts
+++ b/src/routes/pieces/presets/new/+page.server.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { project, project } from '$lib/server/db/schema'
+import { project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
@@ -17,7 +17,6 @@ export async function load({ parent }) {
 		projectName: project.name
 	})
 	.from(project)
-	.innerJoin(project, eq(project.projectId, project.id))
 	.where(eq(project.userId, user.id))
 	
 	return {


### PR DESCRIPTION
## Summary
- Fixes PostgreSQL syntax error preventing access to `/pieces/presets/new`
- Removes duplicate project import that was causing compilation issues
- Removes invalid self-join query that generated "syntax error at or near '='"

## Changes
- Cleaned up import statement in `src/routes/pieces/presets/new/+page.server.ts`
- Simplified database query to properly fetch user's projects for the form
- Removed unnecessary `.innerJoin()` that was referencing non-existent `projectId` field

## Test plan
- [x] Verify `/pieces/presets/new` loads without PostgreSQL errors
- [x] Confirm user projects are properly fetched for the form
- [ ] Test form functionality with the corrected data

🤖 Generated with [Claude Code](https://claude.ai/code)