### PR TITLE
Improve project selector overlay UX with optional backdrop and relative positioning

### DIFF
--- a/src/lib/components/Overlay.svelte
+++ b/src/lib/components/Overlay.svelte
@@ -4,9 +4,13 @@
 		onClose: () => void
 		title?: string
 		children: import('svelte').Snippet
+		showBackdrop?: boolean
+		anchorElement?: HTMLElement
 	}
 
-	let { isOpen = false, onClose, title, children }: Props = $props()
+	let { isOpen = false, onClose, title, children, showBackdrop = true, anchorElement }: Props = $props()
+
+	let overlayContent: HTMLDivElement
 
 	function handleBackdropClick(event: MouseEvent) {
 		if (event.target === event.currentTarget) {
@@ -19,18 +23,90 @@
 			onClose()
 		}
 	}
+
+	function positionOverlay() {
+		if (!anchorElement || !overlayContent) return
+
+		const rect = anchorElement.getBoundingClientRect()
+		const overlayRect = overlayContent.getBoundingClientRect()
+		
+		// Position below the anchor element by default
+		let top = rect.bottom + 8
+		let left = rect.left
+		
+		// Check if overlay would go off the right edge
+		if (left + overlayRect.width > window.innerWidth) {
+			left = window.innerWidth - overlayRect.width - 16
+		}
+		
+		// Check if overlay would go off the bottom edge
+		if (top + overlayRect.height > window.innerHeight) {
+			top = rect.top - overlayRect.height - 8
+		}
+		
+		// Ensure minimum margins
+		left = Math.max(16, left)
+		top = Math.max(16, top)
+		
+		overlayContent.style.position = 'fixed'
+		overlayContent.style.top = `${top}px`
+		overlayContent.style.left = `${left}px`
+		overlayContent.style.transform = 'none'
+	}
+
+	$effect(() => {
+		if (isOpen && anchorElement) {
+			// Position after the DOM has updated
+			setTimeout(positionOverlay, 0)
+		}
+	})
+
+	$effect(() => {
+		if (!showBackdrop && isOpen) {
+			function handleClickOutside(event: MouseEvent) {
+				if (overlayContent && !overlayContent.contains(event.target as Node) && 
+					anchorElement && !anchorElement.contains(event.target as Node)) {
+					onClose()
+				}
+			}
+
+			document.addEventListener('click', handleClickOutside)
+			return () => document.removeEventListener('click', handleClickOutside)
+		}
+	})
 </script>
 
 {#if isOpen}
-	<div 
-		class="overlay-backdrop" 
-		onclick={handleBackdropClick}
-		onkeydown={handleKeydown}
-		role="dialog"
-		aria-modal="true"
-		aria-labelledby={title ? 'overlay-title' : undefined}
-	>
-		<div class="overlay-content">
+	{#if showBackdrop}
+		<div 
+			class="overlay-backdrop" 
+			onclick={handleBackdropClick}
+			onkeydown={handleKeydown}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={title ? 'overlay-title' : undefined}
+		>
+			<div class="overlay-content" bind:this={overlayContent} class:positioned={anchorElement}>
+				{#if title}
+					<header class="overlay-header">
+						<h2 id="overlay-title">{title}</h2>
+						<button class="close-button" onclick={onClose} aria-label="Close overlay">×</button>
+					</header>
+				{/if}
+				<div class="overlay-body">
+					{@render children()}
+				</div>
+			</div>
+		</div>
+	{:else}
+		<div 
+			class="overlay-content positioned"
+			bind:this={overlayContent}
+			onkeydown={handleKeydown}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby={title ? 'overlay-title' : undefined}
+		>
 			{#if title}
 				<header class="overlay-header">
 					<h2 id="overlay-title">{title}</h2>
@@ -41,7 +117,7 @@
 				{@render children()}
 			</div>
 		</div>
-	</div>
+	{/if}
 {/if}
 
 <style>
@@ -104,5 +180,14 @@
 		padding: 1.5rem;
 		overflow-y: auto;
 		flex: 1;
+	}
+
+	.overlay-content.positioned {
+		position: fixed;
+		z-index: 1000;
+		max-width: 24rem;
+		width: auto;
+		min-width: 16rem;
+		max-height: 70vh;
 	}
 </style>

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -7,6 +7,7 @@
 
 	let isAdmin = $state(false)
 	let showProjectOverlay = $state(false)
+	let projectButton: HTMLButtonElement
 
 	$effect(async () => {
 		const uid = $session.data?.user?.id
@@ -51,7 +52,7 @@
 	<nav>
 		<section>
 			<h1><a href='/'>Rowera</a></h1>
-			<button class="project-selector" onclick={openProjectSelector}>
+			<button class="project-selector" bind:this={projectButton} onclick={openProjectSelector}>
 				{$activeProject.name}
 				<span class="chevron">▼</span>
 			</button>
@@ -121,7 +122,13 @@
 </header>
 {/if}
 
-<Overlay isOpen={showProjectOverlay} onClose={closeProjectOverlay} title="Select Project">
+<Overlay 
+	isOpen={showProjectOverlay} 
+	onClose={closeProjectOverlay} 
+	title="Select Project"
+	showBackdrop={false}
+	anchorElement={projectButton}
+>
 	{#snippet children()}
 		<ProjectSelector 
 			onSelectProject={handleSelectProject}


### PR DESCRIPTION
## Summary
- Made the dark overlay backdrop optional in the Overlay component  
- Added relative positioning for overlays anchored to specific elements
- Updated project selector to appear as a dropdown positioned relative to the button

## Changes
- **Overlay.svelte**: Added `showBackdrop` and `anchorElement` props with positioning logic
- **Header.svelte**: Updated to use new Overlay props for better UX

## Benefits
- More natural dropdown experience for project selector
- Flexible overlay component that supports both modal and dropdown patterns
- Better accessibility with click-outside handling for non-backdrop overlays

🤖 Generated with [Claude Code](https://claude.ai/code)