### PR TITLE
Fix undefined data.packets error in pieces presets creation

### DIFF
--- a/src/routes/pieces/presets/new/+page.server.ts
+++ b/src/routes/pieces/presets/new/+page.server.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { project } from '$lib/server/db/schema'
+import { project, packet } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
@@ -10,16 +10,17 @@ export async function load({ parent }) {
 		throw redirect(302, '/login')
 	}
 	
-	// Get user's projects for the form
-	const userProjects = await db.select({
-		id: project.id,
-		name: project.name,
+	// Get user's packets for the form
+	const userPackets = await db.select({
+		id: packet.id,
+		name: packet.name,
 		projectName: project.name
 	})
-	.from(project)
+	.from(packet)
+	.innerJoin(project, eq(packet.projectId, project.id))
 	.where(eq(project.userId, user.id))
 	
 	return {
-		projects: userProjects
+		packets: userPackets
 	}
 }


### PR DESCRIPTION
## Summary
- Fixed runtime error when accessing the create piece preset page
- The page loader was incorrectly querying projects instead of packets
- Changed loader to return packets array with proper packet and project name data

## Test plan
- [x] Navigate to pieces presets creation page
- [x] Verify dropdown populates with available packets
- [x] Verify no runtime errors occur

🤖 Generated with [Claude Code](https://claude.ai/code)