### PR TITLE
Fix inconsistent session property access in packets routes

### DIFF
--- a/src/routes/api/packets/+server.ts
+++ b/src/routes/api/packets/+server.ts
@@ -5,7 +5,7 @@ import { eq, and } from 'drizzle-orm'
 import type { RequestHandler } from './$types'
 
 export const POST: RequestHandler = async ({ request, locals }) => {
-	if (!locals.session?.userId) {
+	if (!locals.session?.user?.id) {
 		return json({ error: 'Unauthorized' }, { status: 401 })
 	}
 	

--- a/src/routes/api/packets/[id]/+server.ts
+++ b/src/routes/api/packets/[id]/+server.ts
@@ -5,7 +5,7 @@ import { eq, and } from 'drizzle-orm'
 import type { RequestHandler } from './$types'
 
 export const PUT: RequestHandler = async ({ request, params, locals }) => {
-	if (!locals.session?.userId) {
+	if (!locals.session?.user?.id) {
 		return json({ error: 'Unauthorized' }, { status: 401 })
 	}
 	
@@ -20,7 +20,7 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 		const projectResult = await db.select().from(project).where(
 			and(
 				eq(project.id, projectId),
-				eq(project.userId, locals.session.userId)
+				eq(project.userId, locals.session.user.id)
 			)
 		).limit(1)
 		
@@ -50,7 +50,7 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 }
 
 export const DELETE: RequestHandler = async ({ params, locals }) => {
-	if (!locals.session?.userId) {
+	if (!locals.session?.user?.id) {
 		return json({ error: 'Unauthorized' }, { status: 401 })
 	}
 	

--- a/src/routes/packets/[id]/edit/+page.server.ts
+++ b/src/routes/packets/[id]/edit/+page.server.ts
@@ -6,7 +6,7 @@ import { eq, and } from 'drizzle-orm'
 export const load = async ({ params, locals }) => {
 	
 	
-	if (!locals.session?.userId) {
+	if (!locals.session?.user?.id) {
 		throw redirect(302, '/login')
 	}
 	
@@ -23,7 +23,7 @@ export const load = async ({ params, locals }) => {
 	.where(
 		and(
 			eq(packet.id, params.id),
-			eq(project.userId, locals.session.userId)
+			eq(project.userId, locals.session.user.id)
 		)
 	)
 	.limit(1)
@@ -33,7 +33,7 @@ export const load = async ({ params, locals }) => {
 	}
 	
 	// Get user's projects for the form
-	const userProjects = await db.select().from(project).where(eq(project.userId, locals.session.userId))
+	const userProjects = await db.select().from(project).where(eq(project.userId, locals.session.user.id))
 	
 	return {
 		packet: packetQuery[0],


### PR DESCRIPTION
## Summary
- Fixed inconsistent session property access in packet routes that was causing login redirects when editing projects
- Changed `locals.session?.userId` to `locals.session?.user?.id` to match authentication pattern used throughout the application
- Affects 3 files: packet API routes and packet edit page server

## Test plan
- [x] Verify packet routes use consistent session access pattern
- [ ] Test editing projects from root screen no longer redirects to login
- [ ] Verify packet CRUD operations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)