### PR TITLE
Add sign out button to profile page

### DIFF
--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -247,6 +247,9 @@
 			<button onclick={setupDefaults} disabled={setupLoading}>
 				{setupLoading ? 'Setting up…' : 'Setup defaults'}
 			</button>
+			<button onclick={handleLogout}>
+				Sign out
+			</button>
 			{#if setupMessage}
 				<p aria-live="polite">{setupMessage}</p>
 			{/if}


### PR DESCRIPTION
## Summary
- Added a sign out button next to the setup defaults button in the profile stats section
- Uses the existing handleLogout function that calls the signOut auth client method
- Button is positioned without additional styling classes to use existing styles

## Test plan
- [ ] Verify sign out button appears next to setup defaults button on profile page
- [ ] Test that clicking the sign out button successfully logs out the user
- [ ] Confirm button styling matches existing design

🤖 Generated with [Claude Code](https://claude.ai/code)