### PR TITLE
Implement smooth deletion updates without page reloads

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,12 @@
 	import CrudTable from '$lib/components/CrudTable.svelte'
 	
 	let { data } = $props()
+	let projects = $state(data.projects)
+	
+	// Update projects when data changes (e.g., navigating back to page)
+	$effect(() => {
+		projects = data.projects
+	})
 	
 	const columns = [
 		{ key: 'name', header: 'Name' },
@@ -40,8 +46,8 @@
 				})
 				
 				if (response.ok) {
-					// Reload the page to refresh the projects list
-					window.location.reload()
+					// Remove the project from the list without page reload
+					projects = projects.filter(p => p.id !== project.id)
 				} else {
 					console.error('Failed to delete project')
 				}
@@ -61,7 +67,7 @@
 		<h1>{getTimeBasedGreeting()} <span>{$session.data?.user.username}</span></h1>
 
 		<CrudTable 
-			items={data.projects}
+			items={projects}
 			{columns}
 			title="Projects"
 			createUrl="/projects/new"

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
 	import { session, signOut, authClient } from '$lib/auth-client'
 	import { activeProject, type Project } from '$lib/stores/active-project'
 	import Overlay from '$lib/components/Overlay.svelte'
@@ -43,7 +44,7 @@
 	function handleCreateNew() {
 		closeProjectOverlay()
 		// Navigate to create new project page
-		window.location.href = '/projects/new'
+		goto('/projects/new')
 	}
 </script>
 

--- a/src/routes/packets/+page.svelte
+++ b/src/routes/packets/+page.svelte
@@ -3,6 +3,12 @@
 	import PacketsNavigation from '$lib/components/PacketsNavigation.svelte'
 	
 	let { data } = $props()
+	let packets = $state(data.packets)
+	
+	// Update packets when data changes
+	$effect(() => {
+		packets = data.packets
+	})
 	
 	// Packets table configuration
 	const packetColumns = [
@@ -25,7 +31,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					packets = packets.filter(p => p.id !== packet.id)
 				} else {
 					console.error('Failed to delete packet')
 				}
@@ -44,7 +51,7 @@
 <PacketsNavigation activeRoute="/packets" />
 
 <CrudTable 
-	items={data.packets}
+	items={packets}
 	columns={packetColumns}
 	title="Packets"
 	createUrl="/packets/new"

--- a/src/routes/packets/pieces/+page.svelte
+++ b/src/routes/packets/pieces/+page.svelte
@@ -3,6 +3,12 @@
 	import PacketsNavigation from '$lib/components/PacketsNavigation.svelte'
 	
 	let { data } = $props()
+	let pieces = $state(data.pieces)
+	
+	// Update pieces when data changes
+	$effect(() => {
+		pieces = data.pieces
+	})
 	
 	// Pieces table configuration
 	const pieceColumns = [
@@ -25,7 +31,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					pieces = pieces.filter(p => p.id !== piece.id)
 				} else {
 					console.error('Failed to delete piece')
 				}
@@ -44,7 +51,7 @@
 <PacketsNavigation activeRoute="/packets/pieces" />
 
 <CrudTable 
-	items={data.pieces}
+	items={pieces}
 	columns={pieceColumns}
 	title="Pieces"
 	createUrl="/packets/pieces/new"

--- a/src/routes/packets/presets/+page.svelte
+++ b/src/routes/packets/presets/+page.svelte
@@ -3,6 +3,12 @@
 	import PacketsNavigation from '$lib/components/PacketsNavigation.svelte'
 	
 	let { data } = $props()
+	let presets = $state(data.presets)
+	
+	// Update presets when data changes
+	$effect(() => {
+		presets = data.presets
+	})
 	
 	// Presets table configuration
 	const presetColumns = [
@@ -23,7 +29,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					presets = presets.filter(p => p.id !== preset.id)
 				} else {
 					console.error('Failed to delete preset')
 				}
@@ -42,7 +49,7 @@
 <PacketsNavigation activeRoute="/packets/presets" />
 
 <CrudTable 
-	items={data.presets}
+	items={presets}
 	columns={presetColumns}
 	title="Presets"
 	createUrl="/packets/presets/new"

--- a/src/routes/pages/+page.svelte
+++ b/src/routes/pages/+page.svelte
@@ -2,6 +2,12 @@
 	import CrudTable from '$lib/components/CrudTable.svelte'
 	
 	let { data } = $props()
+	let pages = $state(data.pages)
+	
+	// Update pages when data changes
+	$effect(() => {
+		pages = data.pages
+	})
 	
 	const columns = [
 		{ key: 'name', header: 'Page Name' },
@@ -22,8 +28,8 @@
 				})
 				
 				if (response.ok) {
-					// Reload the page to refresh the pages list
-					window.location.reload()
+					// Remove from local state without page reload
+					pages = pages.filter(p => p.id !== page.id)
 				} else {
 					console.error('Failed to delete page')
 				}
@@ -40,7 +46,7 @@
 </svelte:head>
 
 <CrudTable 
-	items={data.pages}
+	items={pages}
 	{columns}
 	title="Pages"
 	createUrl="/pages/new"

--- a/src/routes/partials/+page.svelte
+++ b/src/routes/partials/+page.svelte
@@ -2,6 +2,12 @@
 	import CrudTable from '$lib/components/CrudTable.svelte'
 	
 	let { data } = $props()
+	let partials = $state(data.partials)
+	
+	// Update partials when data changes
+	$effect(() => {
+		partials = data.partials
+	})
 	
 	const columns = [
 		{ key: 'name', header: 'Partial Name' },
@@ -20,8 +26,8 @@
 				})
 				
 				if (response.ok) {
-					// Reload the page to refresh the partials list
-					window.location.reload()
+					// Remove from local state without page reload
+					partials = partials.filter(p => p.id !== partial.id)
 				} else {
 					console.error('Failed to delete partial')
 				}
@@ -38,7 +44,7 @@
 </svelte:head>
 
 <CrudTable 
-	items={data.partials}
+	items={partials}
 	{columns}
 	title="Partials"
 	createUrl="/partials/new"

--- a/src/routes/pieces/+page.svelte
+++ b/src/routes/pieces/+page.svelte
@@ -5,6 +5,18 @@
 	let { data } = $props()
 	let activeTab = $state('pieces')
 	
+	// Reactive state for each tab's data
+	let packets = $state(data.packets)
+	let pieces = $state(data.pieces)
+	let presets = $state(data.presets)
+	
+	// Update data when props change
+	$effect(() => {
+		packets = data.packets
+		pieces = data.pieces
+		presets = data.presets
+	})
+	
 	// Packets table configuration
 	const packetColumns = [
 		{ key: 'name', header: 'Packet Name' },
@@ -49,7 +61,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					packets = packets.filter(p => p.id !== packet.id)
 				} else {
 					console.error('Failed to delete packet')
 				}
@@ -67,7 +80,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					pieces = pieces.filter(p => p.id !== piece.id)
 				} else {
 					console.error('Failed to delete piece')
 				}
@@ -85,7 +99,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					presets = presets.filter(p => p.id !== preset.id)
 				} else {
 					console.error('Failed to delete preset')
 				}
@@ -128,7 +143,7 @@
 
 {#if activeTab === 'packets'}
 	<CrudTable 
-		items={data.packets}
+		items={packets}
 		columns={packetColumns}
 		title="Packets"
 		createUrl="/pieces/packets/new"
@@ -137,7 +152,7 @@
 	/>
 {:else if activeTab === 'pieces'}
 	<CrudTable 
-		items={data.pieces}
+		items={pieces}
 		columns={pieceColumns}
 		title="Pieces"
 		createUrl="/pieces/new"
@@ -146,7 +161,7 @@
 	/>
 {:else if activeTab === 'presets'}
 	<CrudTable 
-		items={data.presets}
+		items={presets}
 		columns={presetColumns}
 		title="Presets"
 		createUrl="/pieces/presets/new"

--- a/src/routes/posts/+page.svelte
+++ b/src/routes/posts/+page.svelte
@@ -5,6 +5,18 @@
 	let { data } = $props()
 	let activeTab = $state('posts')
 	
+	// Reactive state for each tab's data
+	let publications = $state(data.publications)
+	let posts = $state(data.posts)
+	let presets = $state(data.presets)
+	
+	// Update data when props change
+	$effect(() => {
+		publications = data.publications
+		posts = data.posts
+		presets = data.presets
+	})
+	
 	// Publications table configuration
 	const publicationColumns = [
 		{ key: 'name', header: 'Publication Name' },
@@ -49,7 +61,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					publications = publications.filter(p => p.id !== publication.id)
 				} else {
 					console.error('Failed to delete publication')
 				}
@@ -67,7 +80,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					posts = posts.filter(p => p.id !== post.id)
 				} else {
 					console.error('Failed to delete post')
 				}
@@ -85,7 +99,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					presets = presets.filter(p => p.id !== preset.id)
 				} else {
 					console.error('Failed to delete preset')
 				}
@@ -128,7 +143,7 @@
 
 {#if activeTab === 'publications'}
 	<CrudTable 
-		items={data.publications}
+		items={publications}
 		columns={publicationColumns}
 		title="Publications"
 		createUrl="/posts/publications/new"
@@ -137,7 +152,7 @@
 	/>
 {:else if activeTab === 'posts'}
 	<CrudTable 
-		items={data.posts}
+		items={posts}
 		columns={postColumns}
 		title="Posts"
 		createUrl="/posts/new"
@@ -146,7 +161,7 @@
 	/>
 {:else if activeTab === 'presets'}
 	<CrudTable 
-		items={data.presets}
+		items={presets}
 		columns={presetColumns}
 		title="Presets"
 		createUrl="/posts/presets/new"

--- a/src/routes/primitives/+page.svelte
+++ b/src/routes/primitives/+page.svelte
@@ -3,6 +3,12 @@
 	
 	let { data } = $props()
 	// If we reach this page, user is already confirmed as admin by the page loader
+	let primitives = $state(data.primitives)
+	
+	// Update primitives when data changes
+	$effect(() => {
+		primitives = data.primitives
+	})
 	
 	const columns = [
 		{ key: 'name', header: 'Primitive Name' },
@@ -27,7 +33,8 @@
 				})
 				
 				if (response.ok) {
-					window.location.reload()
+					// Remove from local state without page reload
+					primitives = primitives.filter(p => p.id !== primitive.id)
 				} else {
 					const error = await response.json()
 					alert(error.error || 'Failed to delete primitive')
@@ -46,7 +53,7 @@
 </svelte:head>
 
 <CrudTable 
-	items={data.primitives}
+	items={primitives}
 	{columns}
 	title="Primitives"
 	createLabel="New Primitive"


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` with reactive state updates across all pages
- Eliminate page flashing during delete operations for much smoother UX
- Remove all `window.location` usage in favor of SvelteKit navigation patterns

## Changes Made
✅ **Reactive State Management**: Implemented `$state` runes for all list data  
✅ **Smooth Deletions**: Delete operations now update local state instead of reloading  
✅ **Data Synchronization**: Added `$effect` hooks to keep data in sync  
✅ **Proper Navigation**: Replaced `window.location.href` with SvelteKit `goto()`  

## Pages Updated
- **Projects** (`/src/routes/+page.svelte`) - Main projects list
- **Posts** (`/src/routes/posts/+page.svelte`) - Posts, publications, presets tabs
- **Pieces** (`/src/routes/pieces/+page.svelte`) - Pieces, packets, presets tabs  
- **Pages** (`/src/routes/pages/+page.svelte`) - Pages management
- **Partials** (`/src/routes/partials/+page.svelte`) - Partials management
- **Primitives** (`/src/routes/primitives/+page.svelte`) - Admin primitives
- **Packets** (`/src/routes/packets/+page.svelte`) - Packets management
- **Packet Pieces** (`/src/routes/packets/pieces/+page.svelte`) - Packet pieces
- **Packet Presets** (`/src/routes/packets/presets/+page.svelte`) - Packet presets
- **Header** (`/src/routes/Header.svelte`) - Navigation improvements

## Technical Implementation
- **Before**: `window.location.reload()` caused full page refreshes
- **After**: `items = items.filter(i => i.id !== deletedItem.id)` for instant updates
- **Data Sync**: `$effect(() => { localState = data.propName })` keeps data fresh
- **Navigation**: `goto('/path')` instead of `window.location.href = '/path'`

## Test Plan
- [x] Verify all delete operations work without page flashing
- [x] Confirm data stays synchronized on navigation
- [x] Test that no `window.location` references remain
- [x] Validate smooth user experience across all affected pages

🤖 Generated with [Claude Code](https://claude.ai/code)