### PR TITLE
Fix content not updating on project change

### DIFF
--- a/src/lib/components/ProjectSelector.svelte
+++ b/src/lib/components/ProjectSelector.svelte
@@ -1,38 +1,41 @@
 <script lang="ts">
-	import { activeProject, type Project } from '$lib/stores/active-project'
-	import { session } from '$lib/auth-client'
+	import { activeProject, type Project } from '$lib/stores/active-project';
+	import { session } from '$lib/auth-client';
+	import { invalidateAll } from '$app/navigation';
 
 	interface Props {
-		onSelectProject: (project: Project) => void
-		onCreateNew: () => void
+		onSelectProject: (project: Project) => void;
+		onCreateNew: () => void;
 	}
 
-	let { onSelectProject, onCreateNew }: Props = $props()
+	let { onSelectProject, onCreateNew }: Props = $props();
 
-	let projects: Project[] = $state([])
-	let loading = $state(true)
-	let error = $state('')
+	let projects: Project[] = $state([]);
+	let loading = $state(true);
+	let error = $state('');
 
 	$effect(async () => {
-		if (!$session.data?.user?.id) return
-		
-		try {
-			const response = await fetch('/api/projects')
-			if (!response.ok) {
-				throw new Error('Failed to fetch projects')
-			}
-			const data = await response.json()
-			projects = data.projects || []
-		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to load projects'
-		} finally {
-			loading = false
-		}
-	})
+		if (!$session.data?.user?.id) return;
 
-	function handleSelectProject(project: Project) {
-		activeProject.setActive(project)
-		onSelectProject(project)
+		try {
+			const response = await fetch('/api/projects');
+			if (!response.ok) {
+				throw new Error('Failed to fetch projects');
+			}
+			const data = await response.json();
+			projects = data.projects || [];
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load projects';
+		} finally {
+			loading = false;
+		}
+	});
+
+	async function handleSelectProject(project: Project) {
+		activeProject.setActive(project);
+		onSelectProject(project);
+		// Invalidate all cached data to refresh content for the new project
+		await invalidateAll();
 	}
 </script>
 
@@ -44,8 +47,8 @@
 	{:else}
 		<div class="project-list">
 			{#each projects as project (project.id)}
-				<button 
-					class="project-item" 
+				<button
+					class="project-item"
 					class:active={$activeProject.id === project.id}
 					onclick={() => handleSelectProject(project)}
 				>
@@ -55,7 +58,7 @@
 					</div>
 				</button>
 			{/each}
-			
+
 			{#if projects.length === 0}
 				<div class="empty-state">
 					<p>No projects found</p>
@@ -63,11 +66,9 @@
 				</div>
 			{/if}
 		</div>
-		
+
 		<div class="actions">
-			<button class="create-button" onclick={onCreateNew}>
-				+ Create New Project
-			</button>
+			<button class="create-button" onclick={onCreateNew}> + Create New Project </button>
 		</div>
 	{/if}
 </div>
@@ -77,7 +78,8 @@
 		min-height: 200px;
 	}
 
-	.loading, .error {
+	.loading,
+	.error {
 		text-align: center;
 		padding: 2rem;
 		color: var(--text-muted, #666);

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -1,140 +1,137 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { session, signOut, authClient } from '$lib/auth-client'
-	import { activeProject, type Project } from '$lib/stores/active-project'
-	import Overlay from '$lib/components/Overlay.svelte'
-	import ProjectSelector from '$lib/components/ProjectSelector.svelte'
+	import { session, signOut, authClient } from '$lib/auth-client';
+	import { activeProject, type Project } from '$lib/stores/active-project';
+	import Overlay from '$lib/components/Overlay.svelte';
+	import ProjectSelector from '$lib/components/ProjectSelector.svelte';
 
-	let isAdmin = $state(false)
-	let showProjectOverlay = $state(false)
-	let projectButton: HTMLButtonElement
+	let isAdmin = $state(false);
+	let showProjectOverlay = $state(false);
+	let projectButton: HTMLButtonElement;
 
 	$effect(async () => {
-		const uid = $session.data?.user?.id
+		const uid = $session.data?.user?.id;
 		if (!uid) {
-			isAdmin = false
-			return
+			isAdmin = false;
+			return;
 		}
 		// Check permissions using Better Auth admin client
 		const { data, error } = await authClient.admin.hasPermission({
 			userId: uid,
-			permission: { "user": ["create"] }
-		})
+			permission: { user: ['create'] }
+		});
 
-		isAdmin = data?.success && !error
-	})
+		isAdmin = data?.success && !error;
+	});
 
 	async function handleLogout() {
-		await signOut()
+		await signOut();
 	}
 
 	function openProjectSelector() {
-		showProjectOverlay = true
+		showProjectOverlay = true;
 	}
 
 	function closeProjectOverlay() {
-		showProjectOverlay = false
+		showProjectOverlay = false;
 	}
 
 	function handleSelectProject(project: Project) {
-		closeProjectOverlay()
+		closeProjectOverlay();
 	}
 
 	function handleCreateNew() {
-		closeProjectOverlay()
+		closeProjectOverlay();
 		// Navigate to create new project page
-		goto('/projects/new')
+		goto('/projects/new');
 	}
 </script>
 
 {#if $session.data?.user}
-<header>
-	<nav>
-		<section>
-			<h1><a href='/'>Rowera</a></h1>
-			<button class="project-selector" bind:this={projectButton} onclick={openProjectSelector}>
-				{$activeProject.name}
-				<span class="chevron">▼</span>
-			</button>
-		</section>
-		
-		<section>
-			<ul>				
-				<li aria-current={page.url.pathname === '/projects' ? 'page' : undefined}>
-					<a href="/projects">Projects</a>
-				</li>
-				<li aria-current={page.url.pathname === '/pages' ? 'page' : undefined}>
-					<a href="/pages">Pages</a>
-				</li>
-				<li aria-current={page.url.pathname.startsWith('/posts') ? 'page' : undefined}>
-					<a href="/posts">Posts</a>
-				</li>
-				<li aria-current={page.url.pathname.startsWith('/pieces') ? 'page' : undefined}>
-					<a href="/pieces">Pieces</a>
-				</li>
-				<li aria-current={page.url.pathname === '/partials' ? 'page' : undefined}>
-					<a href="/partials">Partials</a>
-				</li>
-				{#if isAdmin}
-					<li aria-current={page.url.pathname === '/primitives' ? 'page' : undefined}>
-						<a href="/primitives">Primitives</a>
+	<header>
+		<nav>
+			<section>
+				<h1><a href="/">Rowera</a></h1>
+				<button class="project-selector" bind:this={projectButton} onclick={openProjectSelector}>
+					{$activeProject.name}
+					<span class="chevron">▼</span>
+				</button>
+			</section>
+
+			<section>
+				<ul>
+					<li aria-current={page.url.pathname === '/projects' ? 'page' : undefined}>
+						<a href="/projects">Projects</a>
 					</li>
-				{/if}
-				<li>
-					<button>Preview</button>
-				</li>
-			</ul>
-		</section>
-		
-		<section>
-			<ul>
-				<li aria-current={page.url.pathname === '/presentation' ? 'page' : undefined}>
-					<a href="/presentation">Presentation</a>
-				</li>
-				<li aria-current={page.url.pathname === '/preferences' ? 'page' : undefined}>
-					<a href="/preferences">Preferences</a>
-				</li>
-				<li aria-current={page.url.pathname === '/profile' ? 'page' : undefined}>
-					<a href="/profile">Profile</a>
-				</li>
-			</ul>
-		</section>
-	</nav>
-</header>
+					<li aria-current={page.url.pathname === '/pages' ? 'page' : undefined}>
+						<a href="/pages">Pages</a>
+					</li>
+					<li aria-current={page.url.pathname.startsWith('/posts') ? 'page' : undefined}>
+						<a href="/posts">Posts</a>
+					</li>
+					<li aria-current={page.url.pathname.startsWith('/pieces') ? 'page' : undefined}>
+						<a href="/pieces">Pieces</a>
+					</li>
+					<li aria-current={page.url.pathname === '/partials' ? 'page' : undefined}>
+						<a href="/partials">Partials</a>
+					</li>
+					{#if isAdmin}
+						<li aria-current={page.url.pathname === '/primitives' ? 'page' : undefined}>
+							<a href="/primitives">Primitives</a>
+						</li>
+					{/if}
+					<li>
+						<button>Preview</button>
+					</li>
+				</ul>
+			</section>
+
+			<section>
+				<ul>
+					<li aria-current={page.url.pathname === '/presentation' ? 'page' : undefined}>
+						<a href="/presentation">Presentation</a>
+					</li>
+					<li aria-current={page.url.pathname === '/preferences' ? 'page' : undefined}>
+						<a href="/preferences">Preferences</a>
+					</li>
+					<li aria-current={page.url.pathname === '/profile' ? 'page' : undefined}>
+						<a href="/profile">Profile</a>
+					</li>
+				</ul>
+			</section>
+		</nav>
+	</header>
 {:else}
-<header>
-	<nav>
-		<section>
-			<h1><a href='/'>Rowera</a></h1>
-		</section>
-		
-		<section>
-			<ul>
-				<li aria-current={page.url.pathname === '/login' ? 'page' : undefined}>
-					<a href="/login">Login</a>
-				</li>
-				<li aria-current={page.url.pathname === '/signup' ? 'page' : undefined}>
-					<a href="/signup">Sign Up</a>
-				</li>
-			</ul>
-		</section>
-	</nav>
-</header>
+	<header>
+		<nav>
+			<section>
+				<h1><a href="/">Rowera</a></h1>
+			</section>
+
+			<section>
+				<ul>
+					<li aria-current={page.url.pathname === '/login' ? 'page' : undefined}>
+						<a href="/login">Login</a>
+					</li>
+					<li aria-current={page.url.pathname === '/signup' ? 'page' : undefined}>
+						<a href="/signup">Sign Up</a>
+					</li>
+				</ul>
+			</section>
+		</nav>
+	</header>
 {/if}
 
-<Overlay 
-	isOpen={showProjectOverlay} 
-	onClose={closeProjectOverlay} 
+<Overlay
+	isOpen={showProjectOverlay}
+	onClose={closeProjectOverlay}
 	title="Select Project"
 	showBackdrop={false}
 	anchorElement={projectButton}
 >
 	{#snippet children()}
-		<ProjectSelector 
-			onSelectProject={handleSelectProject}
-			onCreateNew={handleCreateNew}
-		/>
+		<ProjectSelector onSelectProject={handleSelectProject} onCreateNew={handleCreateNew} />
 	{/snippet}
 </Overlay>
 
@@ -148,7 +145,7 @@
 		text-transform: uppercase;
 		font-weight: 500;
 		font-size: 1.5rem;
-		letter-spacing: .05em;
+		letter-spacing: 0.05em;
 		display: inline;
 		line-height: 1;
 	}
@@ -168,44 +165,44 @@
 	}
 
 	nav > section:nth-child(2) {
-  	flex: 0 0 auto;
-  	margin-inline: auto;
-  	display: flex;
-  	justify-content: center;
+		flex: 0 0 auto;
+		margin-inline: auto;
+		display: flex;
+		justify-content: center;
 	}
 
 	@media (max-width: 64rem) {
-  nav {
-    row-gap: .75rem;
-  }
+		nav {
+			row-gap: 0.75rem;
+		}
 
-  /* Put the middle section on its own row, centered */
-  nav > section:nth-child(2) {
-    order: 3;
-    flex-basis: 100%;
-    margin-inline: 0;
-    justify-content: center;
-  }
+		/* Put the middle section on its own row, centered */
+		nav > section:nth-child(2) {
+			order: 3;
+			flex-basis: 100%;
+			margin-inline: 0;
+			justify-content: center;
+		}
 
-  /* Let side sections share the first row */
-  nav > section:nth-child(1),
-  nav > section:nth-child(3) {
-    flex: 1 1 50%;
-  }
-}
+		/* Let side sections share the first row */
+		nav > section:nth-child(1),
+		nav > section:nth-child(3) {
+			flex: 1 1 50%;
+		}
+	}
 
 	ul {
 		list-style: none;
 		display: flex;
 		align-items: baseline;
-		gap: .5rem;
+		gap: 0.5rem;
 		font-weight: 500;
 	}
 
 	li {
-		padding: .125em .5em;
-		border-radius: .25em;
-		transition: all .2s ease;
+		padding: 0.125em 0.5em;
+		border-radius: 0.25em;
+		transition: all 0.2s ease;
 		line-height: 1.5;
 	}
 
@@ -223,14 +220,14 @@
 
 	section:first-child span {
 		position: relative;
-		top: -.5em;
-		left: -.25em;
-		opacity: .5;
+		top: -0.5em;
+		left: -0.25em;
+		opacity: 0.5;
 	}
 
 	section:last-child {
-		font-size: .875rem;
-		opacity: .75;
+		font-size: 0.875rem;
+		opacity: 0.75;
 	}
 
 	section:last-child ul {


### PR DESCRIPTION
## Summary
- Fixes issue where content didn't update when switching projects
- Previously required hard page reloads to see new project content
- Now automatically refreshes all cached data when project changes

## Changes
- Added `invalidateAll()` import to ProjectSelector component
- Modified `handleSelectProject` to call `invalidateAll()` after project selection
- Server-side load functions now re-run with updated `activeProjectId` cookie

## Technical Details
The issue occurred because:
1. Project selection only updated client-side store and cookie
2. SvelteKit cached page data and didn't re-run server load functions
3. Load functions filter data by `activeProjectId` from cookies

The fix ensures that when a project is selected, `invalidateAll()` forces SvelteKit to re-run all server-side load functions, which then read the updated cookie and fetch data for the new project.

## Test plan
- [x] Switch between different projects in the project selector
- [x] Verify content updates immediately without page reload
- [x] Test across different pages (packets, pages, posts, pieces, etc.)
- [x] Confirm build succeeds with no syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)