### PR TITLE
Fix packet edit navigation to preserve tab context

### DIFF
--- a/src/routes/packets/[id]/edit/+page.svelte
+++ b/src/routes/packets/[id]/edit/+page.svelte
@@ -1,8 +1,17 @@
 <script>
 	import CrudForm from '$lib/components/CrudForm.svelte'
 	import { goto } from '$app/navigation'
+	import { browser } from '$app/environment'
 	
 	let { data } = $props()
+	
+	// Determine return URL based on context
+	const getReturnUrl = () => {
+		if (!browser) return '/packets'
+		const urlParams = new URLSearchParams(window.location.search)
+		return urlParams.get('return') || 
+			(document.referrer.includes('/packets/pieces') ? '/packets/pieces' : '/packets')
+	}
 	
 	const fields = [
 		{
@@ -37,7 +46,7 @@
 			})
 			
 			if (response.ok) {
-				goto('/packets')
+				goto(getReturnUrl())
 			} else {
 				console.error('Failed to update packet')
 			}
@@ -52,6 +61,6 @@
 	{fields}
 	item={data.packet}
 	submitLabel="Update Packet"
-	cancelUrl="/packets"
+	cancelUrl={getReturnUrl()}
 	onSubmit={handleSubmit}
 />

--- a/src/routes/packets/pieces/+page.svelte
+++ b/src/routes/packets/pieces/+page.svelte
@@ -14,7 +14,11 @@
 	const pieceColumns = [
 		{ key: 'name', header: 'Piece Name' },
 		{ key: 'slug', header: 'Slug' },
-		{ key: 'packetName', header: 'Packet' },
+		{ 
+			key: 'packetName', 
+			header: 'Packet',
+			render: (item) => `<a href="/packets/${item.packetId}/edit?return=/packets/pieces" class="link">${item.packetName}</a>`
+		},
 		{ key: 'presetName', header: 'Preset' },
 		{ 
 			key: 'createdAt', 
@@ -58,3 +62,14 @@
 	editUrl={(item) => `/packets/pieces/${item.id}/edit`}
 	onDelete={handleDeletePiece}
 />
+
+<style>
+	:global(.link) {
+		color: var(--accent-color);
+		text-decoration: none;
+	}
+	
+	:global(.link:hover) {
+		text-decoration: underline;
+	}
+</style>


### PR DESCRIPTION
## Summary
- Fixed packet edit navigation to return users to the correct tab after editing
- Added context-aware navigation that checks URL parameters and referrer
- Made packet names clickable in pieces table with proper return navigation
- Updated cancel button to also respect the return context

## Test plan
- [ ] Navigate to pieces tab (/packets/pieces)
- [ ] Click on a packet name to edit it
- [ ] Verify you return to pieces tab after saving or canceling
- [ ] Test editing packets from the main packets tab still works correctly
- [ ] Verify referrer-based fallback works when no return parameter is provided

🤖 Generated with [Claude Code](https://claude.ai/code)