### PR TITLE
Fix preset and publication forms to use active project

### DIFF
--- a/src/routes/packets/presets/[id]/edit/+page.server.ts
+++ b/src/routes/packets/presets/[id]/edit/+page.server.ts
@@ -3,24 +3,27 @@ import { preset, project, packet } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
-export async function load({ params, parent }) {
+export async function load({ params, parent, cookies }) {
 	const { user } = await parent()
 	
 	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
+	// Get active project from cookie
+	const activeProjectId = cookies.get('activeProjectId')
+	
 	// Get the preset with ownership verification
-	const preset = await db.select({
+	const presetResult = await db.select({
 		id: preset.id,
 		name: preset.name,
-		projectId: preset.projectId,
+		packetId: preset.packetId,
 		createdAt: preset.createdAt,
 		updatedAt: preset.updatedAt
 	})
 	.from(preset)
-	.innerJoin(project, eq(preset.projectId, project.id))
-	.innerJoin(project, eq(project.projectId, project.id))
+	.innerJoin(packet, eq(preset.packetId, packet.id))
+	.innerJoin(project, eq(packet.projectId, project.id))
 	.where(
 		and(
 			eq(preset.id, params.id),
@@ -29,22 +32,26 @@ export async function load({ params, parent }) {
 	)
 	.limit(1)
 	
-	if (!preset.length) {
+	if (!presetResult.length) {
 		throw error(404, 'Preset not found')
 	}
 	
-	// Get user's projects for the form
-	const userProjects = await db.select({
-		id: project.id,
-		name: project.name,
+	// Get packets for the active project only
+	const userPackets = await db.select({
+		id: packet.id,
+		name: packet.name,
 		projectName: project.name
 	})
-	.from(project)
-	.innerJoin(project, eq(project.projectId, project.id))
-	.where(eq(project.userId, user.id))
+	.from(packet)
+	.innerJoin(project, eq(packet.projectId, project.id))
+	.where(
+		activeProjectId 
+			? eq(packet.projectId, activeProjectId)
+			: eq(project.userId, user.id)
+	)
 	
 	return {
-		preset: preset[0],
-		projects: userProjects
+		preset: presetResult[0],
+		packets: userPackets
 	}
 }

--- a/src/routes/packets/presets/[id]/edit/+page.svelte
+++ b/src/routes/packets/presets/[id]/edit/+page.svelte
@@ -19,7 +19,7 @@
 			required: true,
 			options: data.packets.map(packet => ({
 				value: packet.id,
-				label: `${packet.name} (${packet.projectName})`
+				label: packet.name
 			}))
 		}
 	]

--- a/src/routes/packets/presets/new/+page.svelte
+++ b/src/routes/packets/presets/new/+page.svelte
@@ -19,7 +19,7 @@
 			required: true,
 			options: data.packets.map(packet => ({
 				value: packet.id,
-				label: `${packet.name} (${packet.projectName})`
+				label: packet.name
 			}))
 		}
 	]

--- a/src/routes/pieces/presets/[id]/edit/+page.svelte
+++ b/src/routes/pieces/presets/[id]/edit/+page.svelte
@@ -19,7 +19,7 @@
 			required: true,
 			options: data.packets.map(packet => ({
 				value: packet.id,
-				label: `${packet.name} (${packet.projectName})`
+				label: packet.name
 			}))
 		}
 	]
@@ -33,7 +33,7 @@
 			})
 			
 			if (response.ok) {
-				goto('/pieces')
+				goto('/packets/pieces')
 			} else {
 				console.error('Failed to update preset')
 			}
@@ -48,6 +48,6 @@
 	{fields}
 	item={data.preset}
 	submitLabel="Update Preset"
-	cancelUrl="/pieces"
+	cancelUrl="/packets/pieces"
 	onSubmit={handleSubmit}
 />

--- a/src/routes/pieces/presets/new/+page.server.ts
+++ b/src/routes/pieces/presets/new/+page.server.ts
@@ -3,14 +3,17 @@ import { project, packet } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export async function load({ parent }) {
+export async function load({ parent, cookies }) {
 	const { user } = await parent()
 	
 	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
-	// Get user's packets for the form
+	// Get active project from cookie
+	const activeProjectId = cookies.get('activeProjectId')
+	
+	// Get packets for the active project only
 	const userPackets = await db.select({
 		id: packet.id,
 		name: packet.name,
@@ -18,7 +21,11 @@ export async function load({ parent }) {
 	})
 	.from(packet)
 	.innerJoin(project, eq(packet.projectId, project.id))
-	.where(eq(project.userId, user.id))
+	.where(
+		activeProjectId 
+			? eq(packet.projectId, activeProjectId)
+			: eq(project.userId, user.id)
+	)
 	
 	return {
 		packets: userPackets

--- a/src/routes/pieces/presets/new/+page.svelte
+++ b/src/routes/pieces/presets/new/+page.svelte
@@ -19,7 +19,7 @@
 			required: true,
 			options: data.packets.map(packet => ({
 				value: packet.id,
-				label: `${packet.name} (${packet.projectName})`
+				label: packet.name
 			}))
 		}
 	]
@@ -33,7 +33,7 @@
 			})
 			
 			if (response.ok) {
-				goto('/pieces')
+				goto('/packets/pieces')
 			} else {
 				console.error('Failed to create preset')
 			}
@@ -47,6 +47,6 @@
 	title="Create Packet Preset"
 	{fields}
 	submitLabel="Create Preset"
-	cancelUrl="/pieces"
+	cancelUrl="/packets/pieces"
 	onSubmit={handleSubmit}
 />

--- a/src/routes/posts/publications/[id]/edit/+page.server.ts
+++ b/src/routes/posts/publications/[id]/edit/+page.server.ts
@@ -33,11 +33,7 @@ export async function load({ params, parent }) {
 		throw error(404, 'Publication not found')
 	}
 	
-	// Get all user's projects for the select field
-	const userProjects = await db.select().from(project).where(eq(project.userId, user.id))
-	
 	return {
-		publication: publicationResult[0],
-		projects: userProjects
+		publication: publicationResult[0]
 	}
 }

--- a/src/routes/posts/publications/[id]/edit/+page.svelte
+++ b/src/routes/posts/publications/[id]/edit/+page.svelte
@@ -18,25 +18,21 @@
 			type: 'text',
 			placeholder: 'publication-url-slug',
 			required: true
-		},
-		{
-			name: 'projectId',
-			label: 'Project',
-			type: 'select',
-			required: true,
-			options: data.projects.map(project => ({
-				value: project.id,
-				label: project.name
-			}))
 		}
 	]
 	
 	async function handleSubmit(formData) {
 		try {
+			// Keep the existing project ID - publications shouldn't move between projects
+			const formDataWithProject = {
+				...formData,
+				projectId: data.publication.projectId
+			}
+			
 			const response = await fetch(`/api/publications/${data.publication.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify(formDataWithProject)
 			})
 			
 			if (response.ok) {

--- a/src/routes/posts/publications/new/+page.server.ts
+++ b/src/routes/posts/publications/new/+page.server.ts
@@ -3,17 +3,30 @@ import { project } from '$lib/server/db/schema'
 import { redirect } from '@sveltejs/kit'
 import { eq } from 'drizzle-orm'
 
-export async function load({ parent }) {
+export async function load({ parent, cookies }) {
 	const { user } = await parent()
 
 	if (!user?.id) {
 		throw redirect(302, '/login')
 	}
 	
-	// Get all user's projects for the select field
-	const userProjects = await db.select().from(project).where(eq(project.userId, user.id))
+	// Get active project from cookie
+	const activeProjectId = cookies.get('activeProjectId')
+	
+	// Get active project details
+	let activeProject = null
+	if (activeProjectId) {
+		const result = await db.select()
+			.from(project)
+			.where(eq(project.id, activeProjectId))
+			.limit(1)
+		
+		if (result.length > 0) {
+			activeProject = result[0]
+		}
+	}
 	
 	return {
-		projects: userProjects
+		activeProject
 	}
 }

--- a/src/routes/posts/publications/new/+page.svelte
+++ b/src/routes/posts/publications/new/+page.svelte
@@ -18,25 +18,21 @@
 			type: 'text',
 			placeholder: 'publication-url-slug',
 			required: true
-		},
-		{
-			name: 'projectId',
-			label: 'Project',
-			type: 'select',
-			required: true,
-			options: data.projects.map(project => ({
-				value: project.id,
-				label: project.name
-			}))
 		}
 	]
 	
 	async function handleSubmit(formData) {
 		try {
+			// Add the active project ID to the form data
+			const formDataWithProject = {
+				...formData,
+				projectId: data.activeProject?.id
+			}
+			
 			const response = await fetch('/api/publications', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify(formDataWithProject)
 			})
 			
 			if (response.ok) {


### PR DESCRIPTION
## Summary
- Fixed preset creation/editing to automatically use active project instead of requiring manual selection
- Fixed publication creation/editing to use active project context
- Fixed broken database queries in preset server files that had incorrect joins
- Fixed tab navigation to return users to the correct tab after editing

## Changes Made
- **Packet Presets**: Removed project dropdown, now automatically uses active project
- **Piece Presets**: Removed project dropdown, fixed navigation to return to `/packets/pieces` tab
- **Publications**: Removed project dropdown from creation, simplified editing form
- **Server Fixes**: Fixed broken database queries with proper joins and active project filtering
- **UI Improvements**: Simplified packet labels by removing redundant project name suffixes

## Test Plan
- [x] Create packet preset - should only show packets from active project
- [x] Create piece preset - should redirect to correct pieces tab
- [x] Create publication - should use active project automatically
- [x] Edit presets - should maintain project context and return to correct tab
- [x] Verify no project selection dropdowns appear where they shouldn't

🤖 Generated with [Claude Code](https://claude.ai/code)