### PR TITLE
Fix project selection to auto-select last used project

### DIFF
--- a/src/lib/stores/active-project.ts
+++ b/src/lib/stores/active-project.ts
@@ -11,7 +11,7 @@ export interface Project {
 
 const defaultProject: Project = {
 	id: 'default',
-	name: 'Default project',
+	name: 'Select project',
 	userId: '',
 	createdAt: new Date(),
 	updatedAt: new Date()

--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -25,6 +25,28 @@
 		isAdmin = data?.success && !error;
 	});
 
+	// Auto-select the most recently updated project if currently on default
+	$effect(async () => {
+		const uid = $session.data?.user?.id;
+		if (!uid || $activeProject.id !== 'default') return;
+
+		try {
+			const response = await fetch('/api/projects');
+			if (!response.ok) return;
+
+			const { projects } = await response.json();
+			if (projects && projects.length > 0) {
+				// Sort by updatedAt descending and select the most recent
+				const sortedProjects = [...projects].sort((a, b) =>
+					new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+				);
+				activeProject.setActive(sortedProjects[0]);
+			}
+		} catch (err) {
+			console.error('Failed to auto-select project:', err);
+		}
+	});
+
 	async function handleLogout() {
 		await signOut();
 	}

--- a/src/routes/packets/pieces/+page.server.ts
+++ b/src/routes/packets/pieces/+page.server.ts
@@ -10,13 +10,31 @@ export async function load({ parent, cookies }) {
     throw redirect(302, '/login')
   }
 
-  const activeProjectId = cookies.get('activeProjectId')
+  let activeProjectId = cookies.get('activeProjectId')
+
+  // If activeProjectId is 'default', look up the actual Default project
+  if (activeProjectId === 'default') {
+    const defaultProject = await db
+      .select()
+      .from(project)
+      .where(and(eq(project.userId, user.id), eq(project.name, 'Default')))
+      .limit(1)
+
+    if (defaultProject.length > 0) {
+      activeProjectId = defaultProject[0].id
+    }
+  }
+
+  // If still 'default' or not set, return empty arrays
+  if (!activeProjectId || activeProjectId === 'default') {
+    return {
+      pieces: []
+    }
+  }
 
   // Build base conditions
   const userCondition = eq(project.userId, user.id)
-  const projectCondition = activeProjectId && activeProjectId !== 'default' 
-    ? and(userCondition, eq(project.id, activeProjectId))
-    : userCondition
+  const projectCondition = and(userCondition, eq(project.id, activeProjectId))
 
   // Pieces with packet and preset information
   const userPieces = await db

--- a/src/routes/packets/presets/+page.server.ts
+++ b/src/routes/packets/presets/+page.server.ts
@@ -10,13 +10,31 @@ export async function load({ parent, cookies }) {
     throw redirect(302, '/login')
   }
 
-  const activeProjectId = cookies.get('activeProjectId')
+  let activeProjectId = cookies.get('activeProjectId')
+
+  // If activeProjectId is 'default', look up the actual Default project
+  if (activeProjectId === 'default') {
+    const defaultProject = await db
+      .select()
+      .from(project)
+      .where(and(eq(project.userId, user.id), eq(project.name, 'Default')))
+      .limit(1)
+
+    if (defaultProject.length > 0) {
+      activeProjectId = defaultProject[0].id
+    }
+  }
+
+  // If still 'default' or not set, return empty arrays
+  if (!activeProjectId || activeProjectId === 'default') {
+    return {
+      presets: []
+    }
+  }
 
   // Build base conditions
   const userCondition = eq(project.userId, user.id)
-  const projectCondition = activeProjectId && activeProjectId !== 'default' 
-    ? and(userCondition, eq(project.id, activeProjectId))
-    : userCondition
+  const projectCondition = and(userCondition, eq(project.id, activeProjectId))
 
   // Presets that belong to user's packets
   const userPresets = await db

--- a/src/routes/posts/+page.server.ts
+++ b/src/routes/posts/+page.server.ts
@@ -10,13 +10,39 @@ export async function load({ parent, cookies }) {
     throw redirect(302, '/login')
   }
 
-  const activeProjectId = cookies.get('activeProjectId')
+  let activeProjectId = cookies.get('activeProjectId')
+
+  // If activeProjectId is 'default', look up the actual Default project
+  if (activeProjectId === 'default') {
+    const defaultProject = await db
+      .select()
+      .from(project)
+      .where(and(eq(project.userId, user.id), eq(project.name, 'Default')))
+      .limit(1)
+
+    if (defaultProject.length > 0) {
+      activeProjectId = defaultProject[0].id
+    }
+  }
+
+  // If still 'default' or not set, return empty arrays
+  if (!activeProjectId || activeProjectId === 'default') {
+    const userProjects = await db
+      .select()
+      .from(project)
+      .where(eq(project.userId, user.id))
+
+    return {
+      publications: [],
+      posts: [],
+      presets: [],
+      projects: userProjects
+    }
+  }
 
   // Build base conditions
   const userCondition = eq(project.userId, user.id)
-  const projectCondition = activeProjectId && activeProjectId !== 'default' 
-    ? and(userCondition, eq(project.id, activeProjectId))
-    : userCondition
+  const projectCondition = and(userCondition, eq(project.id, activeProjectId))
 
   // Publications belonging to the user's projects (filtered by active project if specified)
   const userPublications = await db


### PR DESCRIPTION
## Summary
- Auto-selects the most recently updated project when the page loads instead of showing a non-existent "Default project"
- Changes placeholder text from "Default project" to "Select project" for clarity
- Adds logic to look up actual "Default" project by name when needed
- Returns empty arrays on all content pages when no project is selected, preventing confusing mixed content from multiple projects
- Ensures strict filtering by selected project only across all pages (posts, pages, pieces, packets, and their sub-pages)

## Test plan
- [ ] Load the app and verify it auto-selects your most recently updated project
- [ ] Click the project selector and verify it shows "Select project" when no project is selected
- [ ] When no project is selected, verify all content pages show empty lists
- [ ] Select a specific project and verify only that project's content is displayed
- [ ] If you have a project named "Default", verify it filters correctly to that project's content

🤖 Generated with [Claude Code](https://claude.com/claude-code)