### PR TITLE
Add primitive builder for content creation

### DIFF
--- a/src/lib/components/CrudForm.svelte
+++ b/src/lib/components/CrudForm.svelte
@@ -1,15 +1,16 @@
 <script>
-	let { 
+	let {
 		title,
 		fields = [],
 		item = {},
 		submitLabel = 'Save',
 		cancelUrl = '/',
-		onSubmit
+		onSubmit,
+		children
 	} = $props()
-	
+
 	let formData = $state({ ...item })
-	
+
 	function handleSubmit(event) {
 		event.preventDefault()
 		onSubmit?.(formData)
@@ -29,14 +30,14 @@
 			<div class="form-group">
 				<label for={field.name}>{field.label}</label>
 				{#if field.type === 'textarea'}
-					<textarea 
+					<textarea
 						id={field.name}
 						bind:value={formData[field.name]}
 						placeholder={field.placeholder}
 						required={field.required}
 					></textarea>
 				{:else if field.type === 'select'}
-					<select 
+					<select
 						id={field.name}
 						bind:value={formData[field.name]}
 						required={field.required}
@@ -47,7 +48,7 @@
 						{/each}
 					</select>
 				{:else}
-					<input 
+					<input
 						id={field.name}
 						type={field.type || 'text'}
 						bind:value={formData[field.name]}
@@ -57,7 +58,11 @@
 				{/if}
 			</div>
 		{/each}
-		
+
+		{#if children}
+			{@render children()}
+		{/if}
+
 		<div class="form-actions">
 			<button type="submit" class="btn btn-primary">{submitLabel}</button>
 			<a href={cancelUrl} class="btn btn-secondary">Cancel</a>

--- a/src/lib/components/PrimitiveBuilder.svelte
+++ b/src/lib/components/PrimitiveBuilder.svelte
@@ -1,0 +1,269 @@
+<script>
+	let { primitives = $bindable([]), availablePrimitives = [] } = $props()
+
+	let draggedIndex = $state(null)
+	let showDropdown = $state(false)
+	let selectedPrimitiveId = $state('')
+
+	function toggleDropdown() {
+		showDropdown = !showDropdown
+		if (!showDropdown) {
+			selectedPrimitiveId = ''
+		}
+	}
+
+	function addPrimitive() {
+		if (!selectedPrimitiveId) return
+
+		primitives = [...primitives, {
+			id: crypto.randomUUID(),
+			primitiveId: selectedPrimitiveId,
+			order: primitives.length
+		}]
+
+		selectedPrimitiveId = ''
+		showDropdown = false
+	}
+
+	function removePrimitive(index) {
+		primitives = primitives.filter((_, i) => i !== index).map((p, i) => ({ ...p, order: i }))
+	}
+
+	function handleDragStart(index) {
+		draggedIndex = index
+	}
+
+	function handleDragOver(e, index) {
+		e.preventDefault()
+		if (draggedIndex === null || draggedIndex === index) return
+
+		const newPrimitives = [...primitives]
+		const draggedItem = newPrimitives[draggedIndex]
+		newPrimitives.splice(draggedIndex, 1)
+		newPrimitives.splice(index, 0, draggedItem)
+
+		primitives = newPrimitives.map((p, i) => ({ ...p, order: i }))
+		draggedIndex = index
+	}
+
+	function handleDragEnd() {
+		draggedIndex = null
+	}
+
+	function getPrimitiveName(primitiveId) {
+		const primitive = availablePrimitives.find(p => p.id === primitiveId)
+		return primitive?.name || 'Unknown'
+	}
+</script>
+
+<section class="primitive-builder">
+	<h3>Primitives</h3>
+
+	{#if primitives.length === 0}
+		<p class="empty-message">No primitives added yet</p>
+	{/if}
+
+	<ul class="primitive-list">
+		{#each primitives as primitive, index (primitive.id)}
+			<li
+				class="primitive-item"
+				class:dragging={draggedIndex === index}
+				draggable="true"
+				ondragstart={() => handleDragStart(index)}
+				ondragover={(e) => handleDragOver(e, index)}
+				ondragend={handleDragEnd}
+			>
+				<span class="drag-handle" aria-label="Drag to reorder">☰</span>
+
+				<span class="primitive-name">{getPrimitiveName(primitive.primitiveId)}</span>
+
+				<button
+					type="button"
+					onclick={() => removePrimitive(index)}
+					aria-label="Remove primitive"
+					class="remove-button"
+				>
+					Delete
+				</button>
+			</li>
+		{/each}
+	</ul>
+
+	{#if showDropdown}
+		<div class="dropdown-container">
+			<select
+				bind:value={selectedPrimitiveId}
+				class="primitive-select"
+			>
+				<option value="">Select a primitive</option>
+				{#each availablePrimitives as prim}
+					<option value={prim.id}>{prim.name}</option>
+				{/each}
+			</select>
+
+			<div class="dropdown-actions">
+				<button type="button" onclick={addPrimitive} class="confirm-button">
+					Add
+				</button>
+				<button type="button" onclick={toggleDropdown} class="cancel-button">
+					Cancel
+				</button>
+			</div>
+		</div>
+	{:else}
+		<button type="button" onclick={toggleDropdown} class="add-button">
+			+ Add Primitive
+		</button>
+	{/if}
+</section>
+
+<style>
+	.primitive-builder {
+		margin: 1.5rem 0;
+		padding: 1.5rem;
+		border: 1px solid #ddd;
+		border-radius: 8px;
+		background: #fafafa;
+	}
+
+	h3 {
+		margin: 0 0 1rem 0;
+		font-size: 1.2rem;
+		font-weight: 600;
+	}
+
+	.empty-message {
+		color: #666;
+		font-style: italic;
+		margin: 1rem 0;
+	}
+
+	.primitive-list {
+		list-style: none;
+		padding: 0;
+		margin: 0 0 1rem 0;
+	}
+
+	.primitive-item {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.75rem;
+		margin-bottom: 0.5rem;
+		background: white;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		cursor: move;
+		transition: opacity 0.2s, transform 0.2s;
+	}
+
+	.primitive-item:hover {
+		border-color: #999;
+	}
+
+	.primitive-item.dragging {
+		opacity: 0.5;
+	}
+
+	.drag-handle {
+		cursor: grab;
+		color: #999;
+		font-size: 1.2rem;
+		user-select: none;
+	}
+
+	.drag-handle:active {
+		cursor: grabbing;
+	}
+
+	.primitive-name {
+		flex: 1;
+		font-weight: 500;
+	}
+
+	.remove-button {
+		padding: 0.5rem 1rem;
+		background: #f44336;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 0.9rem;
+		font-weight: 500;
+	}
+
+	.remove-button:hover {
+		background: #d32f2f;
+	}
+
+	.dropdown-container {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 1rem;
+		background: white;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+
+	.primitive-select {
+		width: 100%;
+		padding: 0.75rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 1rem;
+	}
+
+	.dropdown-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.confirm-button {
+		flex: 1;
+		padding: 0.75rem 1.5rem;
+		background: #4caf50;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 1rem;
+		font-weight: 500;
+	}
+
+	.confirm-button:hover {
+		background: #45a049;
+	}
+
+	.cancel-button {
+		flex: 1;
+		padding: 0.75rem 1.5rem;
+		background: #6c757d;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 1rem;
+		font-weight: 500;
+	}
+
+	.cancel-button:hover {
+		background: #545b62;
+	}
+
+	.add-button {
+		padding: 0.75rem 1.5rem;
+		background: #4caf50;
+		color: white;
+		border: none;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 1rem;
+		font-weight: 500;
+		width: 100%;
+	}
+
+	.add-button:hover {
+		background: #45a049;
+	}
+</style>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -59,6 +59,7 @@ export const preset = pgTable('preset', {
   name: varchar('name', { length: 255 }).notNull(),
   publicationId: uuid('publication_id').references(() => publication.id, { onDelete: 'cascade' }),
   packetId: uuid('packet_id').references(() => packet.id, { onDelete: 'cascade' }),
+  primitives: json('primitives'), // Array of primitive configurations with order
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()
 });
@@ -140,6 +141,7 @@ export const page = pgTable('page', {
   title: varchar('title', { length: 500 }).notNull(),
   slug: varchar('slug', { length: 500 }).notNull().unique(),
   content: json('content').notNull(), // Array of partial instances with filled data
+  primitives: json('primitives'), // Array of primitive configurations with order
   isPublished: boolean('is_published').notNull().default(false),
   publishedAt: timestamp('published_at'),
   userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
@@ -155,6 +157,7 @@ export const partial = pgTable('partial', {
   slug: varchar('slug', { length: 255 }).notNull(),
   description: text('description'),
   elements: json('elements').notNull(), // Array of semantic HTML elements with their structure
+  primitives: json('primitives'), // Array of primitive configurations with order
   userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
   updatedAt: timestamp('updated_at').notNull().defaultNow()

--- a/src/routes/api/pages/[id]/+server.ts
+++ b/src/routes/api/pages/[id]/+server.ts
@@ -10,20 +10,20 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 	}
 	
 	try {
-		const { name, slug, projectId } = await request.json()
-		
+		const { name, slug, projectId, primitives } = await request.json()
+
 		if (!name?.trim()) {
 			return json({ error: 'Page name is required' }, { status: 400 })
 		}
-		
+
 		if (!slug?.trim()) {
 			return json({ error: 'Page slug is required' }, { status: 400 })
 		}
-		
+
 		if (!projectId) {
 			return json({ error: 'Project is required' }, { status: 400 })
 		}
-		
+
 		// Verify that the new project belongs to the user
 		const projectRows = await db.select()
 			.from(project)
@@ -34,17 +34,18 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 				)
 			)
 			.limit(1)
-		
+
 		if (!projectRows.length) {
 			return json({ error: 'Project not found or access denied' }, { status: 404 })
 		}
-		
+
 		// Update the page with ownership verification through original project
 		const [updatedPage] = await db.update(page)
-			.set({ 
+			.set({
 				name: name.trim(),
 				slug: slug.trim(),
 				projectId,
+				primitives: primitives || null,
 				updatedAt: new Date()
 			})
 			.from(project)

--- a/src/routes/api/partials/[id]/+server.ts
+++ b/src/routes/api/partials/[id]/+server.ts
@@ -10,15 +10,16 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 	}
 	
 	try {
-		const { name } = await request.json()
-		
+		const { name, primitives } = await request.json()
+
 		if (!name?.trim()) {
 			return json({ error: 'Partial name is required' }, { status: 400 })
 		}
-		
-		const [partial] = await db.update(partial)
-			.set({ 
+
+		const [updatedPartial] = await db.update(partial)
+			.set({
 				name: name.trim(),
+				primitives: primitives || null,
 				updatedAt: new Date()
 			})
 			.where(
@@ -29,11 +30,11 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 			)
 			.returning()
 		
-		if (!partial) {
+		if (!updatedPartial) {
 			return json({ error: 'Partial not found' }, { status: 404 })
 		}
-		
-		return json(partial)
+
+		return json(updatedPartial)
 	} catch (error) {
 		console.error('Error updating partial:', error)
 		return json({ error: 'Failed to update partial' }, { status: 500 })

--- a/src/routes/api/presets/[id]/+server.ts
+++ b/src/routes/api/presets/[id]/+server.ts
@@ -10,17 +10,17 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 	}
 	
 	try {
-		const { name, publicationId, packetId } = await request.json()
-		
+		const { name, publicationId, packetId, primitives } = await request.json()
+
 		if (!name?.trim()) {
 			return json({ error: 'Preset name is required' }, { status: 400 })
 		}
-		
+
 		// Must belong to either a publication or a packet, but not both
 		if (!publicationId && !packetId) {
 			return json({ error: 'Either publication or packet is required' }, { status: 400 })
 		}
-		
+
 		if (publicationId && packetId) {
 			return json({ error: 'Preset cannot belong to both publication and packet' }, { status: 400 })
 		}
@@ -88,10 +88,11 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 		
 		// Update the preset
 		const [updatedPreset] = await db.update(preset)
-			.set({ 
+			.set({
 				name: name.trim(),
 				publicationId: publicationId || null,
-				projectId: projectId || null,
+				packetId: packetId || null,
+				primitives: primitives || null,
 				updatedAt: new Date()
 			})
 			.where(eq(preset.id, params.id))

--- a/src/routes/packets/presets/[id]/edit/+page.svelte
+++ b/src/routes/packets/presets/[id]/edit/+page.svelte
@@ -1,9 +1,12 @@
 <script>
 	import CrudForm from '$lib/components/CrudForm.svelte'
+	import PrimitiveBuilder from '$lib/components/PrimitiveBuilder.svelte'
 	import { goto } from '$app/navigation'
-	
+
 	let { data } = $props()
-	
+
+	let primitives = $state(data.preset.primitives || [])
+
 	const fields = [
 		{
 			name: 'name',
@@ -23,15 +26,18 @@
 			}))
 		}
 	]
-	
+
 	async function handleSubmit(formData) {
 		try {
 			const response = await fetch(`/api/presets/${data.preset.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify({
+					...formData,
+					primitives
+				})
 			})
-			
+
 			if (response.ok) {
 				goto('/packets/presets')
 			} else {
@@ -43,11 +49,15 @@
 	}
 </script>
 
-<CrudForm 
+<CrudForm
 	title="Edit Packet Preset"
 	{fields}
 	item={data.preset}
 	submitLabel="Update Preset"
 	cancelUrl="/packets/presets"
 	onSubmit={handleSubmit}
-/>
+>
+	{#snippet children()}
+		<PrimitiveBuilder bind:primitives availablePrimitives={data.primitives} />
+	{/snippet}
+</CrudForm>

--- a/src/routes/pages/[id]/edit/+page.server.ts
+++ b/src/routes/pages/[id]/edit/+page.server.ts
@@ -1,21 +1,22 @@
 import { db } from '$lib/server/db'
-import { page, project } from '$lib/server/db/schema'
+import { page, project, primitive } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
 export const load = async ({ params, locals }) => {
-	
-	
+
+
 	if (!locals.user?.id) {
 		throw redirect(302, '/login')
 	}
-	
+
 	// Get the page with ownership verification through product
-	const page = await db.select({
+	const pageResult = await db.select({
 		id: page.id,
 		name: page.name,
 		slug: page.slug,
 		projectId: page.projectId,
+		primitives: page.primitives,
 		createdAt: page.createdAt,
 		updatedAt: page.updatedAt
 	})
@@ -28,16 +29,20 @@ export const load = async ({ params, locals }) => {
 		)
 	)
 	.limit(1)
-	
-	if (!page.length) {
+
+	if (!pageResult.length) {
 		throw error(404, 'Page not found')
 	}
-	
+
 	// Get all user's projects for the select field
 	const userProjects = await db.select().from(project).where(eq(project.userId, locals.user.id))
-	
+
+	// Get all available primitives
+	const allPrimitives = await db.select().from(primitive)
+
 	return {
-		page: page[0],
-		projects: userProjects
+		page: pageResult[0],
+		projects: userProjects,
+		primitives: allPrimitives
 	}
 }

--- a/src/routes/pages/[id]/edit/+page.svelte
+++ b/src/routes/pages/[id]/edit/+page.svelte
@@ -1,9 +1,12 @@
 <script>
 	import CrudForm from '$lib/components/CrudForm.svelte'
+	import PrimitiveBuilder from '$lib/components/PrimitiveBuilder.svelte'
 	import { goto } from '$app/navigation'
-	
+
 	let { data } = $props()
-	
+
+	let primitives = $state(data.page.primitives || [])
+
 	const fields = [
 		{
 			name: 'name',
@@ -30,15 +33,18 @@
 			}))
 		}
 	]
-	
+
 	async function handleSubmit(formData) {
 		try {
 			const response = await fetch(`/api/pages/${data.page.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify({
+					...formData,
+					primitives
+				})
 			})
-			
+
 			if (response.ok) {
 				goto('/pages')
 			} else {
@@ -50,11 +56,15 @@
 	}
 </script>
 
-<CrudForm 
+<CrudForm
 	title="Edit Page"
 	{fields}
 	item={data.page}
 	submitLabel="Update Page"
 	cancelUrl="/pages"
 	onSubmit={handleSubmit}
-/>
+>
+	{#snippet children()}
+		<PrimitiveBuilder bind:primitives availablePrimitives={data.primitives} />
+	{/snippet}
+</CrudForm>

--- a/src/routes/partials/[id]/edit/+page.server.ts
+++ b/src/routes/partials/[id]/edit/+page.server.ts
@@ -1,27 +1,31 @@
 import { db } from '$lib/server/db'
-import { partial } from '$lib/server/db/schema'
+import { partial, primitive } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
 export const load = async ({ params, locals }) => {
-	
-	
+
+
 	if (!locals.user?.id) {
 		throw redirect(302, '/login')
 	}
-	
-	const partial = await db.select().from(partial).where(
+
+	const partialResult = await db.select().from(partial).where(
 		and(
 			eq(partial.id, params.id),
 			eq(partial.userId, locals.user.id)
 		)
 	).limit(1)
-	
-	if (!partial.length) {
+
+	if (!partialResult.length) {
 		throw error(404, 'Partial not found')
 	}
-	
+
+	// Get all available primitives
+	const allPrimitives = await db.select().from(primitive)
+
 	return {
-		partial: partial[0]
+		partial: partialResult[0],
+		primitives: allPrimitives
 	}
 }

--- a/src/routes/partials/[id]/edit/+page.svelte
+++ b/src/routes/partials/[id]/edit/+page.svelte
@@ -1,9 +1,12 @@
 <script>
 	import CrudForm from '$lib/components/CrudForm.svelte'
+	import PrimitiveBuilder from '$lib/components/PrimitiveBuilder.svelte'
 	import { goto } from '$app/navigation'
-	
+
 	let { data } = $props()
-	
+
+	let primitives = $state(data.partial.primitives || [])
+
 	const fields = [
 		{
 			name: 'name',
@@ -13,15 +16,18 @@
 			required: true
 		}
 	]
-	
+
 	async function handleSubmit(formData) {
 		try {
 			const response = await fetch(`/api/partials/${data.partial.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify({
+					...formData,
+					primitives
+				})
 			})
-			
+
 			if (response.ok) {
 				goto('/partials')
 			} else {
@@ -33,11 +39,15 @@
 	}
 </script>
 
-<CrudForm 
+<CrudForm
 	title="Edit Partial"
 	{fields}
 	item={data.partial}
 	submitLabel="Update Partial"
 	cancelUrl="/partials"
 	onSubmit={handleSubmit}
-/>
+>
+	{#snippet children()}
+		<PrimitiveBuilder bind:primitives availablePrimitives={data.primitives} />
+	{/snippet}
+</CrudForm>

--- a/src/routes/posts/presets/[id]/edit/+page.svelte
+++ b/src/routes/posts/presets/[id]/edit/+page.svelte
@@ -1,9 +1,12 @@
 <script>
 	import CrudForm from '$lib/components/CrudForm.svelte'
+	import PrimitiveBuilder from '$lib/components/PrimitiveBuilder.svelte'
 	import { goto } from '$app/navigation'
-	
+
 	let { data } = $props()
-	
+
+	let primitives = $state(data.preset.primitives || [])
+
 	const fields = [
 		{
 			name: 'name',
@@ -23,15 +26,18 @@
 			}))
 		}
 	]
-	
+
 	async function handleSubmit(formData) {
 		try {
 			const response = await fetch(`/api/presets/${data.preset.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(formData)
+				body: JSON.stringify({
+					...formData,
+					primitives
+				})
 			})
-			
+
 			if (response.ok) {
 				goto('/posts')
 			} else {
@@ -43,11 +49,15 @@
 	}
 </script>
 
-<CrudForm 
+<CrudForm
 	title="Edit Preset"
 	{fields}
 	item={data.preset}
 	submitLabel="Update Preset"
 	cancelUrl="/posts"
 	onSubmit={handleSubmit}
-/>
+>
+	{#snippet children()}
+		<PrimitiveBuilder bind:primitives availablePrimitives={data.primitives} />
+	{/snippet}
+</CrudForm>


### PR DESCRIPTION
## Summary
- Created PrimitiveBuilder component with dropdown selection and drag-drop reordering
- Added primitives JSON field to page, preset, and partial database schemas
- Integrated PrimitiveBuilder into edit forms for pages, publication presets, packet presets, and partials
- Updated CrudForm component to support children snippets for extensibility
- Updated all relevant API endpoints to handle primitives data

## Features
- Click "+ Add Primitive" to open a dropdown selector
- Select a primitive and click "Add" to add it to the vertical list
- Drag and drop primitives to reorder them
- Each primitive displays its name with a "Delete" button
- Primitives are stored as JSON in the database

## Test plan
- [ ] Navigate to edit page for a page/preset/partial
- [ ] Click "+ Add Primitive" and verify dropdown appears
- [ ] Select a primitive and click "Add" to verify it's added to the list
- [ ] Drag primitives to verify reordering works
- [ ] Click "Delete" on a primitive to verify removal
- [ ] Save the form and verify primitives are persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)