### PR TITLE
Make page slug optional with auto-generation and cross-entity uniqueness

### DIFF
--- a/drizzle/0018_remove_page_slug_unique_constraint.sql
+++ b/drizzle/0018_remove_page_slug_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "page" DROP CONSTRAINT IF EXISTS "page_slug_unique";

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -204,7 +204,7 @@ export const postContent = pgTable('post_content', {
 export const page = pgTable('page', {
   id: uuid('id').primaryKey().defaultRandom(),
   title: varchar('title', { length: 500 }).notNull(),
-  slug: varchar('slug', { length: 500 }).notNull().unique(),
+  slug: varchar('slug', { length: 500 }).notNull(),
   publishedAt: timestamp('published_at'),
   userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   projectId: uuid('project_id').references(() => project.id, { onDelete: 'cascade' }),

--- a/src/routes/pages/new/+page.svelte
+++ b/src/routes/pages/new/+page.svelte
@@ -18,7 +18,7 @@
 			label: 'Slug',
 			type: 'text',
 			placeholder: 'page-url-slug',
-			required: true
+			required: false
 		}
 	]
 


### PR DESCRIPTION
## Summary
- Make slug field optional in page creation form - users no longer required to provide a slug
- Auto-generate slug from page title when not provided (lowercase, alphanumeric with hyphens)
- Ensure slug uniqueness across pages, publications, and packets within the same project
- Automatically append counter suffix when slug conflicts detected (e.g., `my-page-1`, `my-page-2`)
- Remove unique constraint from page.slug in database schema
- Add database migration to drop the existing unique constraint

## Test plan
- [ ] Create a page without providing a slug - verify slug is auto-generated from title
- [ ] Create multiple pages with the same title - verify slugs are made unique with counters
- [ ] Create a page with a slug that conflicts with an existing publication - verify slug is made unique
- [ ] Create a page with a slug that conflicts with an existing packet - verify slug is made unique
- [ ] Manually provide a slug during page creation - verify the provided slug is used (and made unique if necessary)
- [ ] Run the database migration and verify the unique constraint is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)