### PR TITLE
Add Plate system for flexible page layouts

### DIFF
--- a/src/lib/components/CrudForm.svelte
+++ b/src/lib/components/CrudForm.svelte
@@ -108,7 +108,7 @@
 	}
 
 	.field-box {
-		background: var(--base-color);
+		background: var(--surface-color);
 		border-radius: 8px;
 		border: 1px solid var(--quad-color);
 		overflow: hidden;
@@ -128,13 +128,13 @@
 	}
 
 	.field-box-content {
-		background: var(--base-color);
+		background: var(--surface-color);
 		padding: 1rem;
 	}
 
 	input, textarea, select {
 		width: 100%;
-		padding: 0.75rem;
+		padding: 0;
 		border: none;
 		font-size: 1rem;
 		background: transparent;
@@ -152,7 +152,7 @@
 	.slug-input-wrapper {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
+		gap: 0;
 	}
 
 	.slug-prefix {

--- a/src/routes/api/pages/+server.ts
+++ b/src/routes/api/pages/+server.ts
@@ -10,7 +10,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	}
 
 	try {
-		const { title, slug, content } = await request.json()
+		const { title, slug, plateId, content } = await request.json()
 
 		if (!title?.trim()) {
 			return json({ error: 'Page title is required' }, { status: 400 })
@@ -46,6 +46,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 			title: title.trim(),
 			slug: slug.trim(),
 			projectId,
+			plateId: plateId || null,
 			userId: locals.user.id
 		}).returning()
 

--- a/src/routes/api/pages/[id]/+server.ts
+++ b/src/routes/api/pages/[id]/+server.ts
@@ -10,7 +10,7 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 	}
 	
 	try {
-		const { name, slug, projectId, primitives } = await request.json()
+		const { name, slug, projectId, plateId, primitives } = await request.json()
 
 		if (!name?.trim()) {
 			return json({ error: 'Page name is required' }, { status: 400 })
@@ -45,6 +45,7 @@ export const PUT: RequestHandler = async ({ request, params, locals }) => {
 				name: name.trim(),
 				slug: slug.trim(),
 				projectId,
+				plateId: plateId || null,
 				primitives: primitives || null,
 				updatedAt: new Date()
 			})

--- a/src/routes/api/plates/+server.ts
+++ b/src/routes/api/plates/+server.ts
@@ -1,0 +1,41 @@
+import { json } from '@sveltejs/kit'
+import { db } from '$lib/server/db'
+import { plate, plateContent } from '$lib/server/db/schema'
+import type { RequestHandler } from './$types'
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user?.id) {
+		return json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	try {
+		const { name, description, items } = await request.json()
+
+		if (!name?.trim()) {
+			return json({ error: 'Plate name is required' }, { status: 400 })
+		}
+
+		const [result] = await db.insert(plate).values({
+			name: name.trim(),
+			description: description?.trim() || null,
+			userId: locals.user.id
+		}).returning()
+
+		// Insert plate content if provided
+		if (items && Array.isArray(items) && items.length > 0) {
+			await db.insert(plateContent).values(
+				items.map((item) => ({
+					plateId: result.id,
+					order: item.order,
+					partialId: item.partialId || null,
+					isContentSlot: item.isContentSlot || false
+				}))
+			)
+		}
+
+		return json(result)
+	} catch (error) {
+		console.error('Error creating plate:', error)
+		return json({ error: 'Failed to create plate' }, { status: 500 })
+	}
+}

--- a/src/routes/api/plates/[id]/+server.ts
+++ b/src/routes/api/plates/[id]/+server.ts
@@ -1,0 +1,87 @@
+import { json } from '@sveltejs/kit'
+import { db } from '$lib/server/db'
+import { plate, plateContent } from '$lib/server/db/schema'
+import { eq, and } from 'drizzle-orm'
+import type { RequestHandler } from './$types'
+
+export const PUT: RequestHandler = async ({ request, params, locals }) => {
+	if (!locals.user?.id) {
+		return json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	try {
+		const { name, description, items } = await request.json()
+
+		if (!name?.trim()) {
+			return json({ error: 'Plate name is required' }, { status: 400 })
+		}
+
+		const [updatedPlate] = await db.update(plate)
+			.set({
+				name: name.trim(),
+				description: description?.trim() || null,
+				updatedAt: new Date()
+			})
+			.where(
+				and(
+					eq(plate.id, params.id),
+					eq(plate.userId, locals.user.id)
+				)
+			)
+			.returning()
+
+		if (!updatedPlate) {
+			return json({ error: 'Plate not found' }, { status: 404 })
+		}
+
+		// Update plate content
+		if (items && Array.isArray(items)) {
+			// Delete existing content
+			await db.delete(plateContent)
+				.where(eq(plateContent.plateId, params.id))
+
+			// Insert new content
+			if (items.length > 0) {
+				await db.insert(plateContent).values(
+					items.map((item) => ({
+						plateId: params.id,
+						order: item.order,
+						partialId: item.partialId || null,
+						isContentSlot: item.isContentSlot || false
+					}))
+				)
+			}
+		}
+
+		return json(updatedPlate)
+	} catch (error) {
+		console.error('Error updating plate:', error)
+		return json({ error: 'Failed to update plate' }, { status: 500 })
+	}
+}
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+	if (!locals.user?.id) {
+		return json({ error: 'Unauthorized' }, { status: 401 })
+	}
+
+	try {
+		const [deletedPlate] = await db.delete(plate)
+			.where(
+				and(
+					eq(plate.id, params.id),
+					eq(plate.userId, locals.user.id)
+				)
+			)
+			.returning()
+
+		if (!deletedPlate) {
+			return json({ error: 'Plate not found' }, { status: 404 })
+		}
+
+		return json({ success: true })
+	} catch (error) {
+		console.error('Error deleting plate:', error)
+		return json({ error: 'Failed to delete plate' }, { status: 500 })
+	}
+}

--- a/src/routes/pages/[slug]/edit/+page.server.ts
+++ b/src/routes/pages/[slug]/edit/+page.server.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { page, project, primitive, primitiveField } from '$lib/server/db/schema'
+import { page, project, primitive, primitiveField, plate } from '$lib/server/db/schema'
 import { error, redirect } from '@sveltejs/kit'
 import { eq, and } from 'drizzle-orm'
 
@@ -16,6 +16,7 @@ export const load = async ({ params, locals }) => {
 		title: page.title,
 		slug: page.slug,
 		projectId: page.projectId,
+		plateId: page.plateId,
 		createdAt: page.createdAt,
 		updatedAt: page.updatedAt
 	})
@@ -36,6 +37,9 @@ export const load = async ({ params, locals }) => {
 	// Get all user's projects for the select field
 	const userProjects = await db.select().from(project).where(eq(project.userId, locals.user.id))
 
+	// Get all user's plates for the select field
+	const userPlates = await db.select().from(plate).where(eq(plate.userId, locals.user.id))
+
 	// Get all available primitives with their fields
 	const allPrimitives = await db.select().from(primitive)
 
@@ -51,6 +55,7 @@ export const load = async ({ params, locals }) => {
 	return {
 		page: pageResult[0],
 		projects: userProjects,
+		plates: userPlates,
 		primitives: primitivesWithFields
 	}
 }

--- a/src/routes/pages/[slug]/edit/+page.svelte
+++ b/src/routes/pages/[slug]/edit/+page.svelte
@@ -53,6 +53,15 @@
 			placeholder: 'page-url-slug',
 			required: true,
 			onInput: handleSlugInput
+		},
+		{
+			name: 'plateId',
+			label: 'Plate',
+			type: 'select',
+			options: [
+				{ value: '', label: 'No Plate (Content Only)' },
+				...data.plates.map(p => ({ value: p.id, label: p.name }))
+			]
 		}
 	]
 
@@ -89,7 +98,7 @@
 <CrudForm
 	title="Edit Page"
 	{fields}
-	item={{ title: titleFieldValue, slug: slugFieldValue }}
+	item={{ title: titleFieldValue, slug: slugFieldValue, plateId: data.page.plateId || '' }}
 	submitLabel="Update Page"
 	cancelUrl="/pages"
 	onSubmit={handleSubmit}

--- a/src/routes/plates/+page.server.ts
+++ b/src/routes/plates/+page.server.ts
@@ -1,0 +1,21 @@
+import { db } from '$lib/server/db'
+import { plate } from '$lib/server/db/schema'
+import { redirect } from '@sveltejs/kit'
+import { eq } from 'drizzle-orm'
+
+export async function load({ parent }) {
+  const { user } = await parent()
+
+  if (!user?.id) {
+    throw redirect(302, '/login')
+  }
+
+  const userPlates = await db
+    .select()
+    .from(plate)
+    .where(eq(plate.userId, user.id))
+
+  return {
+    plates: userPlates
+  }
+}

--- a/src/routes/plates/+page.svelte
+++ b/src/routes/plates/+page.svelte
@@ -1,0 +1,57 @@
+<script>
+	import CrudTable from '$lib/components/CrudTable.svelte'
+
+	let { data } = $props()
+	let plates = $state(data.plates)
+
+	// Update plates when data changes
+	$effect(() => {
+		plates = data.plates
+	})
+
+	const columns = [
+		{ key: 'name', header: 'Name' },
+		{ key: 'description', header: 'Description' },
+		{
+			key: 'createdAt',
+			header: 'Created',
+			render: (item) => {
+				const date = new Date(item.createdAt)
+				return `<time datetime="${date.toISOString()}">${date.toLocaleDateString()}</time>`
+			}
+		}
+	]
+
+	async function handleDelete(plate) {
+		if (confirm(`Are you sure you want to delete "${plate.name}"?`)) {
+			try {
+				const response = await fetch(`/api/plates/${plate.id}`, {
+					method: 'DELETE'
+				})
+
+				if (response.ok) {
+					// Remove from local state without page reload
+					plates = plates.filter(p => p.id !== plate.id)
+				} else {
+					console.error('Failed to delete plate')
+				}
+			} catch (error) {
+				console.error('Error deleting plate:', error)
+			}
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Plates - Rowera CMS</title>
+	<meta name="description" content="Manage your plates" />
+</svelte:head>
+
+<CrudTable
+	items={plates}
+	{columns}
+	title="Plates"
+	createUrl="/plates/new"
+	editUrl={(item) => `/plates/${item.id}/edit`}
+	onDelete={handleDelete}
+/>

--- a/src/routes/plates/[id]/edit/+page.server.ts
+++ b/src/routes/plates/[id]/edit/+page.server.ts
@@ -1,0 +1,40 @@
+import { db } from '$lib/server/db'
+import { plate, plateContent, partial } from '$lib/server/db/schema'
+import { error, redirect } from '@sveltejs/kit'
+import { eq, and } from 'drizzle-orm'
+
+export const load = async ({ params, locals }) => {
+	if (!locals.user?.id) {
+		throw redirect(302, '/login')
+	}
+
+	const plateResult = await db.select().from(plate).where(
+		and(
+			eq(plate.id, params.id),
+			eq(plate.userId, locals.user.id)
+		)
+	).limit(1)
+
+	if (!plateResult.length) {
+		throw error(404, 'Plate not found')
+	}
+
+	// Get plate content items
+	const contentItems = await db
+		.select()
+		.from(plateContent)
+		.where(eq(plateContent.plateId, params.id))
+		.orderBy(plateContent.order)
+
+	// Get all available partials for the user
+	const userPartials = await db
+		.select()
+		.from(partial)
+		.where(eq(partial.userId, locals.user.id))
+
+	return {
+		plate: plateResult[0],
+		items: contentItems,
+		partials: userPartials
+	}
+}

--- a/src/routes/plates/[id]/edit/+page.svelte
+++ b/src/routes/plates/[id]/edit/+page.svelte
@@ -1,0 +1,194 @@
+<script>
+	import CrudForm from '$lib/components/CrudForm.svelte'
+	import { goto } from '$app/navigation'
+
+	let { data } = $props()
+
+	let items = $state(data.items || [])
+
+	const fields = [
+		{
+			name: 'name',
+			label: 'Plate Name',
+			type: 'text',
+			placeholder: 'Enter plate name',
+			required: true
+		},
+		{
+			name: 'description',
+			label: 'Description',
+			type: 'textarea',
+			placeholder: 'Optional description'
+		}
+	]
+
+	function addPartial(partialId) {
+		items = [...items, {
+			order: items.length,
+			partialId,
+			isContentSlot: false
+		}]
+	}
+
+	function addContentSlot() {
+		items = [...items, {
+			order: items.length,
+			partialId: null,
+			isContentSlot: true
+		}]
+	}
+
+	function removeItem(index) {
+		items = items.filter((_, i) => i !== index).map((item, i) => ({
+			...item,
+			order: i
+		}))
+	}
+
+	function moveUp(index) {
+		if (index === 0) return
+		const newItems = [...items]
+		;[newItems[index - 1], newItems[index]] = [newItems[index], newItems[index - 1]]
+		items = newItems.map((item, i) => ({ ...item, order: i }))
+	}
+
+	function moveDown(index) {
+		if (index === items.length - 1) return
+		const newItems = [...items]
+		;[newItems[index], newItems[index + 1]] = [newItems[index + 1], newItems[index]]
+		items = newItems.map((item, i) => ({ ...item, order: i }))
+	}
+
+	async function handleSubmit(formData) {
+		try {
+			const response = await fetch(`/api/plates/${data.plate.id}`, {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					...formData,
+					items
+				})
+			})
+
+			if (response.ok) {
+				goto('/plates')
+			} else {
+				console.error('Failed to update plate')
+			}
+		} catch (error) {
+			console.error('Error updating plate:', error)
+		}
+	}
+</script>
+
+<CrudForm
+	title="Edit Plate"
+	{fields}
+	item={data.plate}
+	submitLabel="Update Plate"
+	cancelUrl="/plates"
+	onSubmit={handleSubmit}
+>
+	{#snippet children()}
+		<section class="field-box">
+			<header class="field-box-header">
+				<h2>Plate Structure</h2>
+			</header>
+			<div class="field-box-content">
+				<div class="items-list">
+					{#each items as item, index}
+						<div class="item">
+							<div class="item-content">
+								{#if item.isContentSlot}
+									<strong>Content Slot</strong> (Main page content)
+								{:else}
+									{data.partials.find(p => p.id === item.partialId)?.name || 'Unknown partial'}
+								{/if}
+							</div>
+							<div class="item-actions">
+								<button type="button" onclick={() => moveUp(index)} disabled={index === 0}>↑</button>
+								<button type="button" onclick={() => moveDown(index)} disabled={index === items.length - 1}>↓</button>
+								<button type="button" onclick={() => removeItem(index)}>Remove</button>
+							</div>
+						</div>
+					{/each}
+					{#if items.length === 0}
+						<p class="empty-message">No items yet. Add partials or a content slot below.</p>
+					{/if}
+				</div>
+
+				<div class="add-buttons">
+					<button type="button" onclick={addContentSlot}>Add Content Slot</button>
+					{#if data.partials.length > 0}
+						<select onchange={(e) => {
+							if (e.target.value) {
+								addPartial(e.target.value)
+								e.target.value = ''
+							}
+						}}>
+							<option value="">Add Partial...</option>
+							{#each data.partials as partial}
+								<option value={partial.id}>{partial.name}</option>
+							{/each}
+						</select>
+					{/if}
+				</div>
+			</div>
+		</section>
+	{/snippet}
+</CrudForm>
+
+<style>
+	.items-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+
+	.item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.75rem;
+		background: var(--base-color);
+		border: 1px solid var(--quad-color);
+		border-radius: 4px;
+	}
+
+	.item-content {
+		flex: 1;
+	}
+
+	.item-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.item-actions button {
+		padding: 0.25rem 0.5rem;
+		font-size: 0.875rem;
+	}
+
+	.empty-message {
+		text-align: center;
+		color: var(--text-color);
+		opacity: 0.6;
+		padding: 2rem;
+	}
+
+	.add-buttons {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.add-buttons select {
+		flex: 1;
+	}
+
+	.field-box-header h2 {
+		margin: 0;
+		font-weight: 600;
+		font-size: 1rem;
+	}
+</style>

--- a/src/routes/plates/new/+page.server.ts
+++ b/src/routes/plates/new/+page.server.ts
@@ -1,0 +1,20 @@
+import { db } from '$lib/server/db'
+import { partial } from '$lib/server/db/schema'
+import { redirect } from '@sveltejs/kit'
+import { eq } from 'drizzle-orm'
+
+export const load = async ({ locals }) => {
+	if (!locals.user?.id) {
+		throw redirect(302, '/login')
+	}
+
+	// Get all available partials for the user
+	const userPartials = await db
+		.select()
+		.from(partial)
+		.where(eq(partial.userId, locals.user.id))
+
+	return {
+		partials: userPartials
+	}
+}

--- a/src/routes/plates/new/+page.svelte
+++ b/src/routes/plates/new/+page.svelte
@@ -1,0 +1,194 @@
+<script>
+	import CrudForm from '$lib/components/CrudForm.svelte'
+	import { goto } from '$app/navigation'
+
+	let { data } = $props()
+
+	let items = $state([])
+
+	const fields = [
+		{
+			name: 'name',
+			label: 'Plate Name',
+			type: 'text',
+			placeholder: 'Enter plate name',
+			required: true
+		},
+		{
+			name: 'description',
+			label: 'Description',
+			type: 'textarea',
+			placeholder: 'Optional description'
+		}
+	]
+
+	function addPartial(partialId) {
+		items = [...items, {
+			order: items.length,
+			partialId,
+			isContentSlot: false
+		}]
+	}
+
+	function addContentSlot() {
+		items = [...items, {
+			order: items.length,
+			partialId: null,
+			isContentSlot: true
+		}]
+	}
+
+	function removeItem(index) {
+		items = items.filter((_, i) => i !== index).map((item, i) => ({
+			...item,
+			order: i
+		}))
+	}
+
+	function moveUp(index) {
+		if (index === 0) return
+		const newItems = [...items]
+		;[newItems[index - 1], newItems[index]] = [newItems[index], newItems[index - 1]]
+		items = newItems.map((item, i) => ({ ...item, order: i }))
+	}
+
+	function moveDown(index) {
+		if (index === items.length - 1) return
+		const newItems = [...items]
+		;[newItems[index], newItems[index + 1]] = [newItems[index + 1], newItems[index]]
+		items = newItems.map((item, i) => ({ ...item, order: i }))
+	}
+
+	async function handleSubmit(formData) {
+		try {
+			const response = await fetch('/api/plates', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					...formData,
+					items
+				})
+			})
+
+			if (response.ok) {
+				goto('/plates')
+			} else {
+				console.error('Failed to create plate')
+			}
+		} catch (error) {
+			console.error('Error creating plate:', error)
+		}
+	}
+</script>
+
+<CrudForm
+	title="Create Plate"
+	{fields}
+	item={{ name: '', description: '' }}
+	submitLabel="Create Plate"
+	cancelUrl="/plates"
+	onSubmit={handleSubmit}
+>
+	{#snippet children()}
+		<section class="field-box">
+			<header class="field-box-header">
+				<h2>Plate Structure</h2>
+			</header>
+			<div class="field-box-content">
+				<div class="items-list">
+					{#each items as item, index}
+						<div class="item">
+							<div class="item-content">
+								{#if item.isContentSlot}
+									<strong>Content Slot</strong> (Main page content)
+								{:else}
+									{data.partials.find(p => p.id === item.partialId)?.name || 'Unknown partial'}
+								{/if}
+							</div>
+							<div class="item-actions">
+								<button type="button" onclick={() => moveUp(index)} disabled={index === 0}>↑</button>
+								<button type="button" onclick={() => moveDown(index)} disabled={index === items.length - 1}>↓</button>
+								<button type="button" onclick={() => removeItem(index)}>Remove</button>
+							</div>
+						</div>
+					{/each}
+					{#if items.length === 0}
+						<p class="empty-message">No items yet. Add partials or a content slot below.</p>
+					{/if}
+				</div>
+
+				<div class="add-buttons">
+					<button type="button" onclick={addContentSlot}>Add Content Slot</button>
+					{#if data.partials.length > 0}
+						<select onchange={(e) => {
+							if (e.target.value) {
+								addPartial(e.target.value)
+								e.target.value = ''
+							}
+						}}>
+							<option value="">Add Partial...</option>
+							{#each data.partials as partial}
+								<option value={partial.id}>{partial.name}</option>
+							{/each}
+						</select>
+					{/if}
+				</div>
+			</div>
+		</section>
+	{/snippet}
+</CrudForm>
+
+<style>
+	.items-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+
+	.item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.75rem;
+		background: var(--base-color);
+		border: 1px solid var(--quad-color);
+		border-radius: 4px;
+	}
+
+	.item-content {
+		flex: 1;
+	}
+
+	.item-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.item-actions button {
+		padding: 0.25rem 0.5rem;
+		font-size: 0.875rem;
+	}
+
+	.empty-message {
+		text-align: center;
+		color: var(--text-color);
+		opacity: 0.6;
+		padding: 2rem;
+	}
+
+	.add-buttons {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.add-buttons select {
+		flex: 1;
+	}
+
+	.field-box-header h2 {
+		margin: 0;
+		font-weight: 600;
+		font-size: 1rem;
+	}
+</style>


### PR DESCRIPTION
## Summary
This PR introduces a new **Plate** system that allows users to define reusable page layouts with partials (headers, footers, etc.) and content slots.

### Key Features
- ✨ **Flexible Layout System**: Create plates that define the structure of pages
- 🧩 **Partial Integration**: Add any partials to plates in any order
- 📍 **Content Slots**: Define where page-specific content should be inserted
- 🎨 **Per-Page Customization**: Each page/post/piece can select which plate to use (or none)

### Schema Changes
- Added `plate` and `plateContent` tables with proper relations
- Added `plateId` to `page`, `post`, and `piece` tables (nullable)
- `null` plateId = no plate (content only), not a default plate

### What's Included
- Full CRUD operations for plates (create, read, update, delete)
- Plate editor UI with reordering functionality
- Ability to add partials and content slots to plates
- Plate selection dropdown in page editor

### UI Improvements
- ✅ Fixed input field box colors to match list item boxes
- ✅ Adjusted input padding to match title box padding
- ✅ Removed gap between `/` and slug in slug field

### Testing Notes
After merging, you'll need to:
1. Run `bun run db:push` to apply schema changes to the database
2. Create your first plate via the Plates menu
3. Assign plates to pages in the page editor

### Future Work
- [ ] Apply same plate selection to Posts and Pieces
- [ ] Implement rendering logic to actually use plates when displaying pages
- [ ] Add default plate templates for new projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)